### PR TITLE
Test case and config/feedback fix for connection pool timeouts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,18 @@
     <dbWaitFor>database system is ready to accept connections</dbWaitFor>
     <hubWaitFor>Starting HTTPd</hubWaitFor>
 
+    <download.logs>false</download.logs>
+
     <dockerNetwork>default</dockerNetwork>
     <dockerNetworkMode>bridge</dockerNetworkMode>
     <dockerStartTimeout>180000</dockerStartTimeout>
 
     <koji-hub-http-port>80</koji-hub-http-port>
     <koji-hub-https-port>443</koji-hub-https-port>
+
+<!--     <docker.container.koji-hub.ip>127.0.0.1</docker.container.koji-hub.ip>
+    <docker.container.koji-hub.net.ci-network.ip>127.0.0.1</docker.container.koji-hub.net.ci-network.ip>
+ -->
     <koji-hub-address>${docker.container.koji-hub.ip}</koji-hub-address>
   </properties>
 
@@ -197,6 +203,19 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>3.1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model-builder</artifactId>
+      <version>3.1.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -327,6 +346,9 @@
                   <!--suppress MavenModelInspection -->
                   <echo file="${project.build.directory}/docker.properties">
                     <![CDATA[
+download.logs=${download.logs}
+project.build.directory=${project.build.directory}
+
 docker.containers.koji-hub.ports.80/tcp.host=${koji-hub-address}
 docker.containers.koji-hub.ports.443/tcp.host=${koji-hub-address}
 docker.containers.koji-hub.ports.80/tcp.port=${koji-hub-http-port}
@@ -352,7 +374,8 @@ docker.containers.koji-hub.ports.443/tcp.port=${koji-hub-https-port}
               </goals>
               <configuration>
                 <includes>
-                  <include>**/*IT.java</include>
+                  <include>**/ImportBuildConnectionStressIT.java</include>
+                  <!-- <include>**/*IT.java</include> -->
                 </includes>
                 <forkCount>1C</forkCount>
                 <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   <properties>
     <enforcer.skip>true</enforcer.skip>
     <javaVersion>1.8</javaVersion>
-    <jhttpcVersion>1.5</jhttpcVersion>
+    <jhttpcVersion>1.6-SNAPSHOT</jhttpcVersion>
     <rwxVersion>1.1</rwxVersion>
     <httpcVersion>4.4</httpcVersion>
     <atlasVersion>0.16.0</atlasVersion>

--- a/src/main/java/com/redhat/red/build/koji/KojijiErrorInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/KojijiErrorInfo.java
@@ -1,0 +1,35 @@
+package com.redhat.red.build.koji;
+
+/**
+ * Created by jdcasey on 7/24/17.
+ */
+public class KojijiErrorInfo
+{
+    private final String filepath;
+
+    private final Exception error;
+
+    private final boolean temporary;
+
+    public KojijiErrorInfo( final String filepath, final Exception error, final boolean temporary )
+    {
+        this.filepath = filepath;
+        this.error = error;
+        this.temporary = temporary;
+    }
+
+    public String getFilepath()
+    {
+        return filepath;
+    }
+
+    public Exception getError()
+    {
+        return error;
+    }
+
+    public boolean isTemporary()
+    {
+        return temporary;
+    }
+}

--- a/src/main/java/com/redhat/red/build/koji/KojijiErrorInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/KojijiErrorInfo.java
@@ -32,4 +32,11 @@ public class KojijiErrorInfo
     {
         return temporary;
     }
+
+    @Override
+    public String toString()
+    {
+        return "KojijiErrorInfo{" + "filepath='" + filepath + '\'' + ", error=" + error + ", temporary=" + temporary
+                + '}';
+    }
 }

--- a/src/main/java/com/redhat/red/build/koji/config/SimpleKojiConfig.java
+++ b/src/main/java/com/redhat/red/build/koji/config/SimpleKojiConfig.java
@@ -45,12 +45,14 @@ public class SimpleKojiConfig
 
     private String kojiURL;
 
+    private Integer maxConnections;
+
     private Integer timeout;
 
     private SiteConfig kojiSiteConfig;
 
     public SimpleKojiConfig( String id, String kojiURL, String clientKeyCertificateFile, String clientCertificatePassword,
-                             String serverCertificateFile, Integer timeout, Boolean trustSelfSigned )
+                             String serverCertificateFile, Integer timeout, Boolean trustSelfSigned, Integer maxConnections )
     {
         this.clientKeyCertificateFile = clientKeyCertificateFile;
         this.clientCertificatePassword = clientCertificatePassword;
@@ -59,6 +61,7 @@ public class SimpleKojiConfig
         this.trustSelfSigned = trustSelfSigned;
         this.id = id;
         this.kojiURL = kojiURL;
+        this.maxConnections = maxConnections;
     }
 
     @Override
@@ -96,6 +99,7 @@ public class SimpleKojiConfig
             }
 
             builder.withRequestTimeoutSeconds( getTimeout() );
+            builder.withMaxConnections( getMaxConnections() );
 
             kojiSiteConfig = builder.build();
         }
@@ -137,5 +141,10 @@ public class SimpleKojiConfig
     public Integer getTimeout()
     {
         return timeout == null ? DEFAULT_TIMEOUT_SECONDS : timeout;
+    }
+
+    public Integer getMaxConnections()
+    {
+        return maxConnections == null ? SiteConfig.DEFAULT_MAX_CONNECTIONS : maxConnections;
     }
 }

--- a/src/main/java/com/redhat/red/build/koji/config/SimpleKojiConfig.java
+++ b/src/main/java/com/redhat/red/build/koji/config/SimpleKojiConfig.java
@@ -23,6 +23,8 @@ import org.commonjava.util.jhttpc.model.SiteTrustType;
 import java.io.File;
 import java.io.IOException;
 
+import static org.commonjava.util.jhttpc.model.SiteConfig.DEFAULT_CONNECTION_POOL_TIMEOUT_SECONDS;
+
 /**
  * Created by jdcasey on 1/12/16.
  */
@@ -49,15 +51,28 @@ public class SimpleKojiConfig
 
     private Integer timeout;
 
+    private Integer connectionPoolTimeout;
+
     private SiteConfig kojiSiteConfig;
 
+    @Deprecated
     public SimpleKojiConfig( String id, String kojiURL, String clientKeyCertificateFile, String clientCertificatePassword,
                              String serverCertificateFile, Integer timeout, Boolean trustSelfSigned, Integer maxConnections )
     {
+        this( id, kojiURL, clientKeyCertificateFile, clientCertificatePassword, serverCertificateFile, timeout, null,
+              trustSelfSigned, maxConnections );
+    }
+
+    public SimpleKojiConfig( String id, String kojiURL, String clientKeyCertificateFile,
+                             String clientCertificatePassword, String serverCertificateFile, Integer timeout,
+                             Integer connectionPoolTimeout, Boolean trustSelfSigned, Integer maxConnections )
+    {
+
         this.clientKeyCertificateFile = clientKeyCertificateFile;
         this.clientCertificatePassword = clientCertificatePassword;
         this.serverCertificateFile = serverCertificateFile;
         this.timeout = timeout;
+        this.connectionPoolTimeout = connectionPoolTimeout;
         this.trustSelfSigned = trustSelfSigned;
         this.id = id;
         this.kojiURL = kojiURL;
@@ -99,6 +114,7 @@ public class SimpleKojiConfig
             }
 
             builder.withRequestTimeoutSeconds( getTimeout() );
+            builder.withConnectionPoolTimeoutSeconds( getConnectionPoolTimeout() );
             builder.withMaxConnections( getMaxConnections() );
 
             kojiSiteConfig = builder.build();
@@ -141,6 +157,11 @@ public class SimpleKojiConfig
     public Integer getTimeout()
     {
         return timeout == null ? DEFAULT_TIMEOUT_SECONDS : timeout;
+    }
+
+    public Integer getConnectionPoolTimeout()
+    {
+        return timeout == null ? DEFAULT_CONNECTION_POOL_TIMEOUT_SECONDS : connectionPoolTimeout;
     }
 
     public Integer getMaxConnections()

--- a/src/main/java/com/redhat/red/build/koji/config/SimpleKojiConfigBuilder.java
+++ b/src/main/java/com/redhat/red/build/koji/config/SimpleKojiConfigBuilder.java
@@ -38,7 +38,7 @@ public class SimpleKojiConfigBuilder
 
     private Integer timeout;
 
-    private SiteConfig kojiSiteConfig;
+    private Integer maxConnections;
 
     public SimpleKojiConfigBuilder( String kojiURL )
     {
@@ -47,7 +47,7 @@ public class SimpleKojiConfigBuilder
 
     public SimpleKojiConfig build()
     {
-        return new SimpleKojiConfig( kojiSiteId, kojiURL, clientKeyCertificateFile, kojiClientCertificatePassword, serverCertificateFile, timeout, trustSelfSigned );
+        return new SimpleKojiConfig( kojiSiteId, kojiURL, clientKeyCertificateFile, kojiClientCertificatePassword, serverCertificateFile, timeout, trustSelfSigned, maxConnections );
     }
 
     public String getClientKeyCertificateFile()
@@ -127,14 +127,14 @@ public class SimpleKojiConfigBuilder
         return this;
     }
 
-    public SiteConfig getKojiSiteConfig()
+    public Integer getMaxConnections()
     {
-        return kojiSiteConfig;
+        return maxConnections;
     }
 
-    public SimpleKojiConfigBuilder withKojiSiteConfig( SiteConfig kojiSiteConfig )
+    public SimpleKojiConfigBuilder withMaxConnections( Integer maxConnections )
     {
-        this.kojiSiteConfig = kojiSiteConfig;
+        this.maxConnections = maxConnections;
         return this;
     }
 }

--- a/src/main/java/com/redhat/red/build/koji/config/SimpleKojiConfigBuilder.java
+++ b/src/main/java/com/redhat/red/build/koji/config/SimpleKojiConfigBuilder.java
@@ -38,6 +38,8 @@ public class SimpleKojiConfigBuilder
 
     private Integer timeout;
 
+    private Integer connectionPoolTimeout;
+
     private Integer maxConnections;
 
     public SimpleKojiConfigBuilder( String kojiURL )
@@ -47,7 +49,9 @@ public class SimpleKojiConfigBuilder
 
     public SimpleKojiConfig build()
     {
-        return new SimpleKojiConfig( kojiSiteId, kojiURL, clientKeyCertificateFile, kojiClientCertificatePassword, serverCertificateFile, timeout, trustSelfSigned, maxConnections );
+        return new SimpleKojiConfig( kojiSiteId, kojiURL, clientKeyCertificateFile, kojiClientCertificatePassword,
+                                     serverCertificateFile, timeout, connectionPoolTimeout, trustSelfSigned,
+                                     maxConnections );
     }
 
     public String getClientKeyCertificateFile()
@@ -124,6 +128,17 @@ public class SimpleKojiConfigBuilder
     public SimpleKojiConfigBuilder withTimeout( Integer timeout )
     {
         this.timeout = timeout;
+        return this;
+    }
+
+    public Integer getConnectionPoolTimeout()
+    {
+        return connectionPoolTimeout;
+    }
+
+    public SimpleKojiConfigBuilder withConnectionPoolTimeout( Integer connectionPoolTimeout )
+    {
+        this.connectionPoolTimeout = connectionPoolTimeout;
         return this;
     }
 

--- a/src/main/java/com/redhat/red/build/koji/model/KojiImportResult.java
+++ b/src/main/java/com/redhat/red/build/koji/model/KojiImportResult.java
@@ -15,7 +15,7 @@
  */
 package com.redhat.red.build.koji.model;
 
-import com.redhat.red.build.koji.KojiClientException;
+import com.redhat.red.build.koji.KojijiErrorInfo;
 import com.redhat.red.build.koji.model.json.KojiImport;
 import com.redhat.red.build.koji.model.xmlrpc.KojiBuildInfo;
 
@@ -31,7 +31,7 @@ public class KojiImportResult
 
     private KojiImport importInfo;
 
-    private Map<String, KojiClientException> uploadErrors;
+    private Map<String, KojijiErrorInfo> uploadErrors;
 
     public KojiImportResult( KojiImport importInfo )
     {
@@ -54,12 +54,12 @@ public class KojiImportResult
         return importInfo;
     }
 
-    public Map<String, KojiClientException> getUploadErrors()
+    public Map<String, KojijiErrorInfo> getUploadErrors()
     {
         return uploadErrors;
     }
 
-    public KojiImportResult withUploadErrors( Map<String, KojiClientException> errors )
+    public KojiImportResult withUploadErrors( Map<String, KojijiErrorInfo> errors )
     {
         this.uploadErrors = errors;
         return this;

--- a/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiUploaderResult.java
+++ b/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiUploaderResult.java
@@ -28,7 +28,9 @@ public final class KojiUploaderResult
 
     private long uploadSize;
 
-    private KojiClientException error;
+    private Exception error;
+
+    private boolean temporaryError;
 
     private UploadResponse response;
 
@@ -38,14 +40,20 @@ public final class KojiUploaderResult
         this.uploadSize = importFile.getSize();
     }
 
-    public KojiClientException getError()
+    public Exception getError()
     {
         return error;
     }
 
-    public void setError( KojiClientException error )
+    public boolean isTemporaryError()
+    {
+        return temporaryError;
+    }
+
+    public void setError( Exception error, boolean temporaryError )
     {
         this.error = error;
+        this.temporaryError = temporaryError;
     }
 
     public UploadResponse getResponse()

--- a/src/test/java/com/redhat/red/build/koji/it/ImportBuildConnectionStressIT.java
+++ b/src/test/java/com/redhat/red/build/koji/it/ImportBuildConnectionStressIT.java
@@ -17,6 +17,7 @@ package com.redhat.red.build.koji.it;
 
 import com.redhat.red.build.koji.KojiClient;
 import com.redhat.red.build.koji.KojiClientException;
+import com.redhat.red.build.koji.KojijiErrorInfo;
 import com.redhat.red.build.koji.model.ImportFile;
 import com.redhat.red.build.koji.model.KojiImportResult;
 import com.redhat.red.build.koji.model.json.BuildContainer;
@@ -150,7 +151,7 @@ public class ImportBuildConnectionStressIT
 
         KojiImportResult result = client.importBuild( importMetadata, fileSuppliers, session );
 
-        Map<String, KojiClientException> uploadErrors = result.getUploadErrors();
+        Map<String, KojijiErrorInfo> uploadErrors = result.getUploadErrors();
 
         if ( uploadErrors != null && !uploadErrors.isEmpty() )
         {

--- a/src/test/java/com/redhat/red/build/koji/it/ImportBuildConnectionStressIT.java
+++ b/src/test/java/com/redhat/red/build/koji/it/ImportBuildConnectionStressIT.java
@@ -1,0 +1,302 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc. (jcasey@redhat.com)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.red.build.koji.it;
+
+import com.redhat.red.build.koji.KojiClient;
+import com.redhat.red.build.koji.KojiClientException;
+import com.redhat.red.build.koji.model.ImportFile;
+import com.redhat.red.build.koji.model.KojiImportResult;
+import com.redhat.red.build.koji.model.json.BuildContainer;
+import com.redhat.red.build.koji.model.json.KojiImport;
+import com.redhat.red.build.koji.model.json.StandardArchitecture;
+import com.redhat.red.build.koji.model.json.StandardBuildType;
+import com.redhat.red.build.koji.model.json.StandardChecksum;
+import com.redhat.red.build.koji.model.json.VerificationException;
+import com.redhat.red.build.koji.model.xmlrpc.KojiBuildInfo;
+import com.redhat.red.build.koji.model.xmlrpc.KojiSessionInfo;
+import com.redhat.red.build.koji.model.xmlrpc.KojiTaskInfo;
+import com.redhat.red.build.koji.model.xmlrpc.messages.CreateTagRequest;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
+import org.commonjava.maven.atlas.ident.ref.SimpleProjectVersionRef;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Created by jdcasey on 1/14/16.
+ */
+public class ImportBuildConnectionStressIT
+        extends AbstractIT
+{
+
+    private static final int MODULE_COUNT = 16;
+
+    private static final int BUILD_COUNT = 16;
+
+    private ExecutorService executor = Executors.newCachedThreadPool();
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        CountDownLatch latch = new CountDownLatch( BUILD_COUNT );
+        for ( int i = 0; i < BUILD_COUNT; i++ )
+        {
+            final int idx = i;
+            executor.execute( () ->
+                              {
+                                  Thread.currentThread().setName( "Build-" + idx );
+                                  try
+                                  {
+                                      runImport();
+                                  }
+                                  catch ( Exception e )
+                                  {
+                                      fail( "Failed to import build." );
+                                  }
+                                  finally
+                                  {
+                                      latch.countDown();
+                                  }
+                              } );
+        }
+
+        latch.await();
+    }
+
+    private void runImport()
+            throws Exception
+    {
+        KojiClient client = newKojiClient();
+        KojiSessionInfo session = client.login();
+
+        String tagName = getClass().getSimpleName();
+
+        CreateTagRequest req = new CreateTagRequest();
+        req.setTagName( tagName );
+
+        client.createTag( req, session );
+
+        ProjectVersionRef topGav = generateGAV();
+        KojiImport.Builder importBuilder = initImport( topGav );
+
+        boolean packageAdded = client.addPackageToTag( tagName, topGav, session );
+        assertThat( packageAdded, equalTo( true ) );
+
+        List<Supplier<ImportFile>> fileSuppliers =
+                new ArrayList<>( Arrays.asList( addPom( topGav, importBuilder ), addJar( topGav, importBuilder ) ) );
+
+        for ( int i = 1; i < MODULE_COUNT; i++ )
+        {
+            ProjectVersionRef moduleGav = generateGAV();
+            fileSuppliers.add( addPom( moduleGav, importBuilder ) );
+            fileSuppliers.add( addJar( moduleGav, importBuilder ) );
+        }
+
+        KojiImport importMetadata = importBuilder.build();
+
+        System.out.printf( "Starting CGImport using client: %s\n metadata: %s\n fileSuppliers: %s\n session: %s",
+                           client, importMetadata, fileSuppliers, session );
+
+        KojiImportResult result = client.importBuild( importMetadata, fileSuppliers, session );
+
+        Map<String, KojiClientException> uploadErrors = result.getUploadErrors();
+
+        if ( uploadErrors != null && !uploadErrors.isEmpty() )
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.append( "The following upload errors occurred:\n\n" );
+            uploadErrors.forEach( ( k, v ) -> sb.append( k ).append( ":\n\n  " ).append( v ).append( "\n\n" ) );
+            fail( sb.toString() );
+        }
+
+        KojiBuildInfo buildInfo = result.getBuildInfo();
+        assertThat( buildInfo, notNullValue() );
+
+        Integer taskId = client.tagBuild( tagName, buildInfo.getNvr(), session );
+        assertThat( taskId, notNullValue() );
+
+        KojiTaskInfo taskInfo = client.getTaskInfo( taskId, session );
+
+        System.out.println( "State of tag operation: " + taskInfo.getState() );
+    }
+
+    private static List<String> words;
+
+    private static Random rand = new Random();
+
+    @BeforeClass
+    public static void loadWords()
+            throws IOException
+    {
+        words = IOUtils.readLines( Thread.currentThread().getContextClassLoader().getResourceAsStream( "words" ) );
+    }
+
+    private Supplier<ImportFile> addPom( ProjectVersionRef gav, KojiImport.Builder importBuilder )
+            throws IOException
+    {
+        String pomPath = String.format( "%s/%s/%s/%s-%s.pom", gav.getGroupId().replace( '.', '/' ), gav.getArtifactId(),
+                                        gav.getVersionString(), gav.getArtifactId(), gav.getVersionString() );
+
+        Model model = new Model();
+        model.setModelVersion( "4.0.0" );
+        model.setGroupId( gav.getGroupId() );
+        model.setArtifactId( gav.getArtifactId() );
+        model.setVersion( gav.getVersionString() );
+        model.setPackaging( "jar" );
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new MavenXpp3Writer().write( baos, model );
+
+        byte[] pomBytes = baos.toByteArray();
+
+        importBuilder.withNewOutput( 1, new File( pomPath ).getName() )
+                     .withFileSize( pomBytes.length )
+                     .withChecksum( StandardChecksum.md5.name(), DigestUtils.md5Hex( pomBytes ) )
+                     //                                                 .withOutputType( StandardOutputType.maven )
+                     .withMavenInfoAndType( gav )
+                     .parent();
+
+        return () -> new ImportFile( new File( pomPath ).getName(), new ByteArrayInputStream( pomBytes ),
+                                     pomBytes.length );
+    }
+
+    private Supplier<ImportFile> addJar( ProjectVersionRef gav, KojiImport.Builder importBuilder )
+            throws IOException
+    {
+        String jarPath = String.format( "%s/%s/%s/%s-%s.jar", gav.getGroupId().replace( '.', '/' ), gav.getArtifactId(),
+                                        gav.getVersionString(), gav.getArtifactId(), gav.getVersionString() );
+
+        byte[] jarBytes = new byte[16384];
+        rand.nextBytes( jarBytes );
+
+        importBuilder.withNewOutput( 1, new File( jarPath ).getName() )
+                     .withFileSize( jarBytes.length )
+                     .withChecksum( StandardChecksum.md5.name(), DigestUtils.md5Hex( jarBytes ) )
+                     //                                                 .withOutputType( StandardOutputType.maven )
+                     .withMavenInfoAndType( gav )
+                     .parent();
+
+        return () -> new ImportFile( new File( jarPath ).getName(), new ByteArrayInputStream( jarBytes ),
+                                     jarBytes.length );
+    }
+
+    private ProjectVersionRef generateGAV()
+            throws IOException, VerificationException
+    {
+        String group = selectWords( ".", 2 );
+        String artifact = selectWords( null, 1 );
+        String version = selectNumeric( new ArrayList<>( Arrays.asList( ".", "." ) ), 3 );
+
+        return new SimpleProjectVersionRef( group, artifact, version );
+    }
+
+    private KojiImport.Builder initImport( ProjectVersionRef gav )
+    {
+        KojiImport.Builder importBuilder = new KojiImport.Builder();
+
+        int brId = 1;
+        Date start = new Date( System.currentTimeMillis() - 86400 );
+        Date end = new Date( System.currentTimeMillis() - 43200 );
+
+        importBuilder.withNewBuildDescription( gav )
+                     //        KojiImport importMetadata = importBuilder.withNewBuildDescription( "org.foo-bar", "1.1", "1" )
+                     //                                                 .withBuildType( StandardBuildType.maven )
+                     .withExternalBuildId( String.format( "%s-%s-%s", gav.getGroupId(), gav.getArtifactId(),
+                                                          gav.getVersionString() ) )
+                     .withStartTime( start )
+                     .withEndTime( end )
+                     .withBuildSource( "http://build.foo.com" )
+                     .parent()
+                     .withNewBuildRoot( brId )
+                     .withTool( "apache-maven", "3.2.1" )
+                     .withContentGenerator( "test-cg", "1.0" )
+                     .withContainer(
+                             new BuildContainer( StandardBuildType.maven.name(), StandardArchitecture.noarch.name() ) )
+                     .withHost( "linux", StandardArchitecture.x86_64 )
+                     .parent();
+
+        return importBuilder;
+    }
+
+    private String selectNumeric( final List<String> sep, final int count )
+    {
+        StringBuilder sb = new StringBuilder();
+        for ( int i = 0; i < count; i++ )
+        {
+            if ( i > 0 )
+            {
+                sb.append( sep.remove( 0 ) );
+            }
+
+            sb.append( Math.abs( rand.nextInt( 100 ) ) );
+        }
+
+        return sb.toString();
+    }
+
+    private String selectWords( final String sep, final int count )
+    {
+        StringBuilder sb = new StringBuilder();
+        for ( int i = 0; i < count; i++ )
+        {
+            if ( i > 0 )
+            {
+                sb.append( sep );
+            }
+
+            sb.append( Math.abs( rand.nextInt( words.size() ) ) );
+        }
+
+        return sb.toString();
+    }
+
+    private class ProjectInfo
+    {
+        private ProjectVersionRef gav;
+
+        private KojiImport.Builder importBuilder;
+
+        private ProjectInfo( ProjectVersionRef gav, KojiImport.Builder importBuilder )
+        {
+            this.gav = gav;
+            this.importBuilder = importBuilder;
+        }
+    }
+}

--- a/src/test/java/com/redhat/red/build/koji/it/ImportSimpleBuildIT.java
+++ b/src/test/java/com/redhat/red/build/koji/it/ImportSimpleBuildIT.java
@@ -60,19 +60,18 @@ public class ImportSimpleBuildIT
     public void run()
             throws Exception
     {
-        executeSetupScript( "koji grant-cg-access kojiadmin test-cg" );
-
         KojiClient client = newKojiClient();
         KojiSessionInfo session = client.login();
 
+        String tagName = getClass().getSimpleName();
         CreateTagRequest req = new CreateTagRequest();
-        req.setTagName( name.getMethodName() );
+        req.setTagName( tagName );
 
         client.createTag( req, session );
 
         ProjectVersionRef gav = new SimpleProjectVersionRef( "org.foo", "bar", "1.1" );
 
-        boolean packageAdded = client.addPackageToTag( name.getMethodName(), gav, session );
+        boolean packageAdded = client.addPackageToTag( tagName, gav, session );
         assertThat( packageAdded, equalTo( true ) );
 
         Map<String, KojiArchiveType> archiveTypes = client.getArchiveTypeMap( session );
@@ -132,7 +131,7 @@ public class ImportSimpleBuildIT
         KojiBuildInfo buildInfo = result.getBuildInfo();
         assertThat( buildInfo, notNullValue() );
 
-        Integer taskId = client.tagBuild( name.getMethodName(), buildInfo.getNvr(), session );
+        Integer taskId = client.tagBuild( tagName, buildInfo.getNvr(), session );
         assertThat( taskId, notNullValue() );
 
         KojiTaskInfo taskInfo = client.getTaskInfo( taskId, session );

--- a/src/test/java/com/redhat/red/build/koji/it/ImportSimpleBuildIT.java
+++ b/src/test/java/com/redhat/red/build/koji/it/ImportSimpleBuildIT.java
@@ -17,6 +17,7 @@ package com.redhat.red.build.koji.it;
 
 import com.redhat.red.build.koji.KojiClient;
 import com.redhat.red.build.koji.KojiClientException;
+import com.redhat.red.build.koji.KojijiErrorInfo;
 import com.redhat.red.build.koji.model.ImportFile;
 import com.redhat.red.build.koji.model.KojiImportResult;
 import com.redhat.red.build.koji.model.json.StandardChecksum;
@@ -118,7 +119,7 @@ public class ImportSimpleBuildIT
                            client, importMetadata, fileSuppliers, session );
         KojiImportResult result = client.importBuild( importMetadata, fileSuppliers, session );
 
-        Map<String, KojiClientException> uploadErrors = result.getUploadErrors();
+        Map<String, KojijiErrorInfo> uploadErrors = result.getUploadErrors();
 
         if ( uploadErrors != null && !uploadErrors.isEmpty() )
         {

--- a/src/test/java/com/redhat/red/build/koji/it/util/KojiTestUtil.java
+++ b/src/test/java/com/redhat/red/build/koji/it/util/KojiTestUtil.java
@@ -1,0 +1,40 @@
+package com.redhat.red.build.koji.it.util;
+
+import org.commonjava.util.jhttpc.HttpFactory;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileLock;
+import java.util.function.Consumer;
+
+/**
+ * Created by jdcasey on 7/21/17.
+ */
+public final class KojiTestUtil
+{
+    private static File CG_ACCESS_ENABLED =
+            new File( System.getProperty( "project.build.dir", "target" ), "cg-access-enabled.flag" );
+
+    private KojiTestUtil()
+    {
+    }
+
+    public static void enableCGAccess( final HttpFactory factory, Consumer<String> commander )
+            throws Exception
+    {
+        if ( CG_ACCESS_ENABLED.exists() )
+        {
+            return;
+        }
+
+        try (RandomAccessFile f = new RandomAccessFile( CG_ACCESS_ENABLED, "rws" );
+             FileLock lock = f.getChannel().tryLock())
+        {
+            if ( lock != null )
+            {
+                commander.accept( "koji grant-cg-access kojiadmin test-cg" );
+                f.write( 1 );
+            }
+        }
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -18,6 +18,9 @@
     </encoder>
   </appender>
 
+  <!--<logger name="org.commonjava.util.jhttpc.INTERNAL.conn.CloseBlockingConnectionManager" level="TRACE"/>-->
+  <logger name="org.apache.http.wire" level="INFO"/>
+
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>  


### PR DESCRIPTION
See commits for details. This separates the connection pool timeout from the request timeout (implemented in jhttpc, which this updates and adjusts to), and then adds a notion of a temporary upload error to the API (**requires code changes in callers**).

Default connection pool timeout is set to 60 seconds.