### PR TITLE
Remove unused _starstar in KojiTagInfo

### DIFF
--- a/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiTagInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiTagInfo.java
@@ -29,11 +29,6 @@ import java.util.List;
 @StructPart
 public class KojiTagInfo
 {
-
-    @DataKey( "_starstar" )
-    @JsonProperty( "_starstar" )
-    private boolean useKojiKeywords = true;
-
     @DataKey( "id" )
     private int id;
 
@@ -176,21 +171,6 @@ public class KojiTagInfo
     public void setMavenIncludeAll( boolean mavenIncludeAll )
     {
         this.mavenIncludeAll = mavenIncludeAll;
-    }
-
-    public boolean isUseKojiKeywords()
-    {
-        return useKojiKeywords;
-    }
-
-    public boolean getUseKojiKeywords()
-    {
-        return useKojiKeywords;
-    }
-
-    public void setUseKojiKeywords( boolean useKojiKeywords )
-    {
-        this.useKojiKeywords = useKojiKeywords;
     }
 
     @Override

--- a/src/test/java/com/redhat/red/build/koji/model/json/KojiTagInfoTest.java
+++ b/src/test/java/com/redhat/red/build/koji/model/json/KojiTagInfoTest.java
@@ -45,7 +45,6 @@ public class KojiTagInfoTest
         info.setName( "foo" );
         info.setPermission( "bar" );
         info.setPermissionId( 0 );
-        info.setUseKojiKeywords( false );
 
         String json = mapper.writeValueAsString( info );
         System.out.println( json );


### PR DESCRIPTION
I thought _starstar misses one underscore but it turned out this field is not used at all. Remove it. 