### PR TITLE
[1.x] Fix NPE in createRemoteRepository

### DIFF
--- a/src/main/java/com/redhat/red/build/koji/KojiClient.java
+++ b/src/main/java/com/redhat/red/build/koji/KojiClient.java
@@ -946,7 +946,7 @@ public class KojiClient
     public KojiBuildArchiveCollection listArchivesForBuild( final KojiBuildInfo build, final KojiSessionInfo session )
     {
         ListArchivesResponse archivesResponse = doXmlRpcAndWarn( () -> xmlrpcClient.call(
-                new ListArchivesRequest( new KojiArchiveQuery().withBuildId( build.getId() ) ),
+                new ListArchivesRequest( new KojiArchiveQuery().withBuildId( build.getId() ).withType( "maven" ) ),
                 ListArchivesResponse.class, sessionUrlBuilder( session ), STANDARD_REQUEST_MODIFIER ),
                                                                  "Failed to retrieve archives for build: '%s'",
                                                                  build.getNvr() );


### PR DESCRIPTION
We are missing type in the listArchives request, which causes that the result is missing the maven specific fields like group_id, artifact_id etc.

```
org.commonjava.indy.IndyWorkflowException: Cannot retrieve builds for: org.optaplanner:optaplanner-bom:pom:6.5.0.Final-redhat-16. Error: Koji withSession lambda command failed: null
    at org.commonjava.indy.koji.content.KojiContentManagerDecorator.proxyKojiBuild(KojiContentManagerDecorator.java:380) ~[indy-embedder-savant-1.1.11.jar:na]
    at org.commonjava.indy.koji.content.KojiContentManagerDecorator.findKojiBuildAnd(KojiContentManagerDecorator.java:288) ~[indy-embedder-savant-1.1.11.jar:na]
    at org.commonjava.indy.koji.content.KojiContentManagerDecorator.retrieve(KojiContentManagerDecorator.java:186) ~[indy-embedder-savant-1.1.11.jar:na]
    at sun.reflect.GeneratedMethodAccessor147.invoke(Unknown Source) ~[na:na]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_144]
    at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_144]
    at org.jboss.weld.annotated.runtime.InvokableAnnotatedMethod.invokeOnInstance(InvokableAnnotatedMethod.java:97) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.DecoratorProxyMethodHandler.doInvoke(DecoratorProxyMethodHandler.java:80) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.DecoratorProxyMethodHandler.doInvoke(DecoratorProxyMethodHandler.java:69) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.interceptor.util.proxy.TargetInstanceProxyMethodHandler.invoke(TargetInstanceProxyMethodHandler.java:33) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.TargetBeanInstance.invoke(TargetBeanInstance.java:88) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.ProxyMethodHandler.invoke(ProxyMethodHandler.java:100) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.commonjava.indy.core.content.DefaultContentManager$Proxy$_$$_Weld$Proxy$.retrieve(Unknown Source) ~[indy-embedder-savant-1.1.11.jar:na]
    at sun.reflect.GeneratedMethodAccessor229.invoke(Unknown Source) ~[na:na]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_144]
    at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_144]
    at org.jboss.weld.util.reflection.Reflections.invokeAndUnwrap(Reflections.java:401) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.CombinedInterceptorAndDecoratorStackMethodHandler.invoke(CombinedInterceptorAndDecoratorStackMethodHandler.java:62) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.commonjava.indy.core.content.DefaultContentManager$Proxy$_$$_WeldSubclass.retrieve(Unknown Source) ~[indy-embedder-savant-1.1.11.jar:na]
    at org.commonjava.indy.core.ctl.ContentController.get(ContentController.java:147) ~[indy-embedder-savant-1.1.11.jar:na]
    at org.commonjava.indy.core.ctl.ContentController$Proxy$_$$_WeldClientProxy.get(Unknown Source) ~[indy-embedder-savant-1.1.11.jar:na]
    at org.commonjava.indy.core.bind.jaxrs.ContentAccessHandler.doGet(ContentAccessHandler.java:289) ~[indy-embedder-savant-1.1.11.jar:na]
    at org.commonjava.indy.folo.bind.jaxrs.FoloContentAccessResource.doGet(FoloContentAccessResource.java:141) [indy-embedder-savant-1.1.11.jar:na]
    at org.commonjava.indy.folo.bind.jaxrs.FoloContentAccessResource$Proxy$_$$_WeldClientProxy.doGet(Unknown Source) [indy-embedder-savant-1.1.11.jar:na]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_144]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_144]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_144]
    at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_144]
    at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:137) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:296) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:250) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:237) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:356) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:179) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:220) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:56) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:847) [jboss-servlet-api_3.0_spec-1.0.1.Final.jar:1.0.1.Final]
    at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:85) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:130) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at org.commonjava.indy.bind.jaxrs.ResourceManagementFilter.doFilter(ResourceManagementFilter.java:88) [indy-embedder-savant-1.1.11.jar:na]
    at org.commonjava.indy.bind.jaxrs.ResourceManagementFilter$Proxy$_$$_WeldClientProxy.doFilter(Unknown Source) [indy-embedder-savant-1.1.11.jar:na]
    at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:60) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:132) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:85) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:61) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at org.keycloak.adapters.undertow.UndertowAuthenticatedActionsHandler.handleRequest(UndertowAuthenticatedActionsHandler.java:66) [keycloak-undertow-adapter-1.9.8.Final.jar:1.9.8.Final]
    at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:56) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.security.handlers.AuthenticationConstraintHandler.handleRequest(AuthenticationConstraintHandler.java:51) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:45) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:63) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.security.ServletSecurityConstraintHandler.handleRequest(ServletSecurityConstraintHandler.java:56) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:58) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:70) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.security.handlers.SecurityInitialHandler.handleRequest(SecurityInitialHandler.java:76) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at org.commonjava.indy.bind.jaxrs.HeaderDebugger.handleRequest(HeaderDebugger.java:93) [indy-embedder-savant-1.1.11.jar:na]
    at org.keycloak.adapters.undertow.ServletPreAuthActionsHandler.handleRequest(ServletPreAuthActionsHandler.java:69) [keycloak-undertow-adapter-1.9.8.Final.jar:1.9.8.Final]
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:261) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:247) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:76) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:166) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.server.Connectors.executeRootHandler(Connectors.java:197) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:764) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_144]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_144]
    at java.lang.Thread.run(Thread.java:748) [na:1.8.0_144]
Caused by: com.redhat.red.build.koji.KojiClientException: Koji withSession lambda command failed: null
    at com.redhat.red.build.koji.KojiClient.withKojiSession(KojiClient.java:425) ~[kojiji-1.9.jar:1.9]
    at org.commonjava.indy.koji.content.KojiContentManagerDecorator.proxyKojiBuild(KojiContentManagerDecorator.java:304) ~[indy-embedder-savant-1.1.11.jar:na]
    ... 70 common frames omitted
Caused by: java.lang.NullPointerException: null
    at org.commonjava.indy.koji.content.KojiContentManagerDecorator.lambda$createRemoteRepository$2(KojiContentManagerDecorator.java:416) ~[indy-embedder-savant-1.1.11.jar:na]
    at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[na:1.8.0_144]
    at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1374) ~[na:1.8.0_144]
    at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[na:1.8.0_144]
    at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[na:1.8.0_144]
    at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[na:1.8.0_144]
    at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:1.8.0_144]
    at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499) ~[na:1.8.0_144]
    at org.commonjava.indy.koji.content.KojiContentManagerDecorator.createRemoteRepository(KojiContentManagerDecorator.java:418) ~[indy-embedder-savant-1.1.11.jar:na]
    at org.commonjava.indy.koji.content.KojiContentManagerDecorator.lambda$proxyKojiBuild$1(KojiContentManagerDecorator.java:363) ~[indy-embedder-savant-1.1.11.jar:na]
    at com.redhat.red.build.koji.KojiClient.withKojiSession(KojiClient.java:409) ~[kojiji-1.9.jar:1.9]
    ... 71 common frames omitted
```