### PR TITLE
Implement Externalizable for some Koji classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <enforcer.skip>true</enforcer.skip>
         <javaVersion>1.8</javaVersion>
         <jhttpcVersion>1.6</jhttpcVersion>
-        <rwxVersion>2.1</rwxVersion>
+        <rwxVersion>2.2-SNAPSHOT</rwxVersion>
         <httpcVersion>4.4</httpcVersion>
         <atlasVersion>0.16.0</atlasVersion>
         <mockitoVersion>2.7.20</mockitoVersion>

--- a/src/main/java/com/redhat/red/build/koji/model/util/ExternalizableUtils.java
+++ b/src/main/java/com/redhat/red/build/koji/model/util/ExternalizableUtils.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc. (jcasey@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.red.build.koji.model.util;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class ExternalizableUtils
+{
+    public static void writeUTF( ObjectOutput out, String s )
+            throws IOException
+    {
+        if ( s == null )
+        {
+            out.writeBoolean( false );
+        }
+        else
+        {
+            out.writeBoolean( true );
+            out.writeUTF( s );
+        }
+    }
+
+    public static String readUTF( ObjectInput in )
+            throws IOException
+    {
+        if ( in.readBoolean() )
+        {
+            return in.readUTF();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiArchiveInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiArchiveInfo.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.redhat.red.build.koji.model.converter.KojiChecksumTypeConverter;
 import com.redhat.red.build.koji.model.converter.StringListConverter;
+import com.redhat.red.build.koji.model.util.ExternalizableUtils;
 
 import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
@@ -28,6 +29,10 @@ import org.commonjava.rwx.anno.Converter;
 import org.commonjava.rwx.anno.DataKey;
 import org.commonjava.rwx.anno.StructPart;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -38,7 +43,12 @@ import java.util.regex.Pattern;
  */
 @StructPart
 public class KojiArchiveInfo
+    implements Externalizable
 {
+    private static final int VERSION = 1;
+
+    private static final long serialVersionUID = 6877608047448106469L;
+
     @DataKey( "id" )
     @JsonProperty( "id" )
     private Integer archiveId;
@@ -131,6 +141,7 @@ public class KojiArchiveInfo
 
     public KojiArchiveInfo()
     {
+
     }
 
     public String getBuildType()
@@ -480,5 +491,72 @@ public class KojiArchiveInfo
                 ", size=" + size +
                 ", extra=" + extra +
                 '}';
+    }
+
+    @Override
+    public void writeExternal( ObjectOutput out )
+            throws IOException
+    {
+        out.writeInt( VERSION );
+        out.writeObject( archiveId );
+        ExternalizableUtils.writeUTF( out, buildType );
+        out.writeObject( buildTypeId );
+        ExternalizableUtils.writeUTF( out, groupId );
+        ExternalizableUtils.writeUTF( out, artifactId );
+        ExternalizableUtils.writeUTF( out, version );
+        ExternalizableUtils.writeUTF( out, relPath );
+        out.writeObject( platforms );
+        out.writeObject( flags );
+        ExternalizableUtils.writeUTF( out, arch );
+        out.writeObject( rootId );
+        ExternalizableUtils.writeUTF( out, typeExtensions );
+        ExternalizableUtils.writeUTF( out, filename );
+        out.writeObject( buildId );
+        ExternalizableUtils.writeUTF( out, extension );
+        out.writeObject( typeId );
+        ExternalizableUtils.writeUTF( out, checksum );
+        out.writeObject( checksumType );
+        ExternalizableUtils.writeUTF( out, typeDescription );
+        out.writeObject( metadataOnly );
+        out.writeObject( buildrootId );
+        out.writeObject( size );
+        out.writeObject( extra );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Override
+    public void readExternal( ObjectInput in )
+            throws IOException, ClassNotFoundException
+    {
+        int version = in.readInt();
+
+        if ( version != 1 )
+        {
+            throw new IOException( "Invalid version: " + version );
+        }
+
+        this.archiveId = (Integer) in.readObject();
+        this.buildType = ExternalizableUtils.readUTF( in );
+        this.buildTypeId = (Integer) in.readObject();
+        this.groupId = ExternalizableUtils.readUTF( in );
+        this.artifactId = ExternalizableUtils.readUTF( in );
+        this.version = ExternalizableUtils.readUTF( in );
+        this.relPath = ExternalizableUtils.readUTF( in );
+        this.platforms = (List<String>) in.readObject();
+        this.flags = (List<String>) in.readObject();
+        this.arch = ExternalizableUtils.readUTF( in );
+        this.rootId = (Boolean) in.readObject();
+        this.typeExtensions = ExternalizableUtils.readUTF( in );
+        this.filename = ExternalizableUtils.readUTF( in );
+        this.buildId = (Integer) in.readObject();
+        this.extension = ExternalizableUtils.readUTF( in );
+        this.typeId = (Integer) in.readObject();
+        this.checksum = ExternalizableUtils.readUTF( in );
+        this.checksumType = (KojiChecksumType) in.readObject();
+        this.typeDescription = ExternalizableUtils.readUTF( in );
+        this.metadataOnly = (Boolean) in.readObject();
+        this.buildrootId = (Integer) in.readObject();
+        this.size = (Integer) in.readObject();
+        this.extra = (Map<String, Object>) in.readObject();
     }
 }

--- a/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiTagInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiTagInfo.java
@@ -17,10 +17,16 @@ package com.redhat.red.build.koji.model.xmlrpc;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.redhat.red.build.koji.model.converter.StringListConverter;
+import com.redhat.red.build.koji.model.util.ExternalizableUtils;
+
 import org.commonjava.rwx.anno.Converter;
 import org.commonjava.rwx.anno.DataKey;
 import org.commonjava.rwx.anno.StructPart;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.util.List;
 
 /**
@@ -28,7 +34,12 @@ import java.util.List;
  */
 @StructPart
 public class KojiTagInfo
+    implements Externalizable
 {
+    private static final long serialVersionUID = 3783816258249355144L;
+
+    private static final int VERSION = 1;
+
     @DataKey( "id" )
     private int id;
 
@@ -58,7 +69,10 @@ public class KojiTagInfo
     @JsonProperty( "maven_include_all" )
     private boolean mavenIncludeAll = true;
 
-    public KojiTagInfo(){}
+    public KojiTagInfo()
+    {
+
+    }
 
     public KojiTagInfo( int id, String name, String permission, Integer permissionId, List<String> arches, boolean locked,
                         boolean mavenSupport, boolean mavenIncludeAll )
@@ -73,7 +87,7 @@ public class KojiTagInfo
         this.mavenIncludeAll = mavenIncludeAll;
     }
 
-    public KojiTagInfo(String name)
+    public KojiTagInfo( String name )
     {
         this.name = name;
     }
@@ -171,6 +185,43 @@ public class KojiTagInfo
     public void setMavenIncludeAll( boolean mavenIncludeAll )
     {
         this.mavenIncludeAll = mavenIncludeAll;
+    }
+
+    @Override
+    public void writeExternal( ObjectOutput out )
+            throws IOException
+    {
+        out.writeInt( VERSION );
+        out.writeInt( id );
+        ExternalizableUtils.writeUTF( out, name );
+        ExternalizableUtils.writeUTF( out, permission );
+        out.writeObject( permissionId );
+        out.writeObject( arches );
+        out.writeBoolean( locked );
+        out.writeBoolean( mavenSupport );
+        out.writeBoolean( mavenIncludeAll );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Override
+    public void readExternal( ObjectInput in )
+            throws IOException, ClassNotFoundException
+    {
+        int version = in.readInt();
+
+        if ( version != 1 )
+        {
+            throw new IOException( "Invalid version: " + version );
+        }
+
+        this.id = in.readInt();
+        this.name = ExternalizableUtils.readUTF( in );
+        this.permission = ExternalizableUtils.readUTF( in );
+        this.permissionId = (Integer) in.readObject();
+        this.arches = (List<String>) in.readObject();
+        this.locked = in.readBoolean();
+        this.mavenSupport = in.readBoolean();
+        this.mavenIncludeAll = in.readBoolean();
     }
 
     @Override

--- a/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiTaskInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiTaskInfo.java
@@ -16,10 +16,16 @@
 package com.redhat.red.build.koji.model.xmlrpc;
 
 import com.redhat.red.build.koji.model.converter.TimestampConverter;
+import com.redhat.red.build.koji.model.util.ExternalizableUtils;
+
 import org.commonjava.rwx.anno.Converter;
 import org.commonjava.rwx.anno.DataKey;
 import org.commonjava.rwx.anno.StructPart;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.util.Date;
 import java.util.List;
 
@@ -28,7 +34,12 @@ import java.util.List;
  */
 @StructPart
 public class KojiTaskInfo
+    implements Externalizable
 {
+    private static final long serialVersionUID = -4033517639092179002L;
+
+    private static final int VERSION = 1;
+
     @DataKey( "id" )
     private int taskId;
 
@@ -76,6 +87,11 @@ public class KojiTaskInfo
 
     @DataKey( "request" )
     private List<Object> request;
+
+    public KojiTaskInfo()
+    {
+
+    }
 
     public int getTaskId()
     {
@@ -225,5 +241,82 @@ public class KojiTaskInfo
     public void setRequest( List<Object> request )
     {
         this.request = request;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+
+        if ( !( o instanceof KojiTaskInfo ) )
+        {
+            return false;
+        }
+
+        KojiTaskInfo that = (KojiTaskInfo) o;
+
+        return getTaskId() == that.getTaskId();
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Integer.valueOf( getTaskId() ).hashCode();
+    }
+
+    @Override
+    public void writeExternal( ObjectOutput out )
+            throws IOException
+
+    {
+        out.writeInt( VERSION );
+        out.writeInt( taskId );
+        out.writeDouble( weight );
+        out.writeInt( parentTaskId );
+        out.writeInt( channelId );
+        out.writeObject( startTime );
+        ExternalizableUtils.writeUTF( out, label );
+        out.writeInt( priority );
+        out.writeObject( completionTime );
+        out.writeInt( state );
+        out.writeObject( createTime );
+        out.writeInt( ownerId );
+        out.writeInt( hostId );
+        ExternalizableUtils.writeUTF( out, method );
+        ExternalizableUtils.writeUTF( out, arch );
+        out.writeObject( request );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Override
+    public void readExternal( ObjectInput in )
+            throws IOException, ClassNotFoundException
+    {
+        int version = in.readInt();
+
+        if ( version != 1 )
+        {
+            throw new IOException( "Invalid version: " + version );
+        }
+
+        this.taskId = in.readInt();
+        this.weight = in.readDouble();
+        this.parentTaskId = in.readInt();
+        this.channelId = in.readInt();
+        this.startTime = (Date) in.readObject();
+        this.label = ExternalizableUtils.readUTF( in );
+        this.priority = in.readInt();
+        this.completionTime = (Date) in.readObject();
+        this.state = in.readInt();
+        this.createTime = (Date) in.readObject();
+        this.ownerId = in.readInt();
+        this.hostId = in.readInt();
+        this.method = ExternalizableUtils.readUTF( in );
+        this.arch = ExternalizableUtils.readUTF( in );
+        this.request = (List<Object>) in.readObject();
     }
 }

--- a/src/test/java/com/redhat/red/build/koji/model/util/ExternalizableUtilsTest.java
+++ b/src/test/java/com/redhat/red/build/koji/model/util/ExternalizableUtilsTest.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright ( C ) 2015 Red Hat, Inc. ( jcasey@redhat.com )
+ *
+ * Licensed under the Apache License, Version 2.0 ( the "License" );
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.red.build.koji.model.util;
+
+import org.junit.Test;
+
+import com.redhat.red.build.koji.model.xmlrpc.KojiArchiveInfo;
+import com.redhat.red.build.koji.model.xmlrpc.KojiBuildInfo;
+import com.redhat.red.build.koji.model.xmlrpc.KojiChecksumType;
+import com.redhat.red.build.koji.model.xmlrpc.KojiTagInfo;
+import com.redhat.red.build.koji.model.xmlrpc.KojiTaskInfo;
+import com.redhat.red.build.koji.model.xmlrpc.messages.AbstractKojiMessageTest;
+import com.redhat.red.build.koji.model.xmlrpc.messages.GetArchiveResponse;
+import com.redhat.red.build.koji.model.xmlrpc.messages.GetBuildResponse;
+import com.redhat.red.build.koji.model.xmlrpc.messages.GetTaskResponse;
+import com.redhat.red.build.koji.model.xmlrpc.messages.TagResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class ExternalizableUtilsTest
+    extends AbstractKojiMessageTest
+{
+    @Test
+    public void testExternalizeKojiArchiveInfo()
+            throws Exception
+    {
+        GetArchiveResponse parsed = parseCapturedMessage( GetArchiveResponse.class, "getArchive-response.xml" );
+        KojiArchiveInfo o1 = parsed.getArchiveInfo();
+        KojiArchiveInfo o2 = new KojiArchiveInfo();
+
+        try ( ByteArrayOutputStream bout = new ByteArrayOutputStream(); ObjectOutputStream out = new ObjectOutputStream( bout ) )
+        {
+            o1.writeExternal( out );
+
+            out.close();
+
+            try ( ByteArrayInputStream bin = new ByteArrayInputStream( bout.toByteArray() ); ObjectInputStream in = new ObjectInputStream( bin ) )
+            {
+                o2.readExternal( in );
+            }
+        }
+
+        assertThat( o2.getArtifactId(), equalTo( "netty-all" ) );
+        assertThat( o2.getBuildType(), equalTo( "maven" ) );
+        assertThat( o2.getBuildTypeId(), equalTo( 2 ) );
+        assertThat( o2.getBuildId(), equalTo( 558964 ) );
+        assertThat( o2.getBuildrootId(), equalTo( null ) );
+        assertThat( o2.getChecksum(), equalTo( "a04e5b625b09efcf1af859f365f44e60" ) );
+        assertThat( o2.getChecksumType(), equalTo( KojiChecksumType.md5 ) );
+        assertThat( o2.getExtra(), equalTo( null ) );
+        assertThat( o2.getFilename(), equalTo( "netty-all-4.1.9.Final-redhat-1.pom" ) );
+        assertThat( o2.getGroupId(), equalTo( "io.netty" ) );
+        assertThat( o2.getArchiveId(), equalTo( 1907538 ) );
+        assertThat( o2.getMetadataOnly(), equalTo( false ) );
+        assertThat( o2.getSize(), equalTo( 21110 ) );
+        assertThat( o2.getTypeDescription(), equalTo( "Maven Project Object Management file" ) );
+        assertThat( o2.getTypeExtensions(), equalTo(  "pom" ) );
+        assertThat( o2.getTypeId(), equalTo( 3 ) );
+        assertThat( o2.getTypeName(), equalTo( "pom" ) );
+        assertThat( o2.getVersion(), equalTo( "4.1.9.Final-redhat-1" ) );
+    }
+
+    @Test
+    public void testExternalizeKojiBuildInfo()
+            throws Exception
+    {
+        GetBuildResponse parsed = parseCapturedMessage( GetBuildResponse.class, "getBuild-response.xml" );
+        KojiBuildInfo o1 = parsed.getBuildInfo();
+        KojiBuildInfo o2 = new KojiBuildInfo();
+
+        try ( ByteArrayOutputStream bout = new ByteArrayOutputStream(); ObjectOutputStream out = new ObjectOutputStream( bout ) )
+        {
+            o1.writeExternal( out );
+
+            out.close();
+
+            try ( ByteArrayInputStream bin = new ByteArrayInputStream( bout.toByteArray() ); ObjectInputStream in = new ObjectInputStream( bin ) )
+            {
+                o2.readExternal( in );
+            }
+        }
+
+        assertThat( o2.getNvr(), equalTo( "org.dashbuilder-dashbuilder-parent-metadata-0.4.0.Final" ) );
+    }
+
+    @Test
+    public void testExternalizeKojiTagInfo()
+            throws Exception
+    {
+        TagResponse parsed = parseCapturedMessage( TagResponse.class, "getTag-response.xml" );
+        KojiTagInfo o1 = parsed.getTagInfo();
+        KojiTagInfo o2 = new KojiTagInfo();
+
+        try ( ByteArrayOutputStream bout = new ByteArrayOutputStream(); ObjectOutputStream out = new ObjectOutputStream( bout ) )
+        {
+            o1.writeExternal( out );
+
+            out.close();
+
+            try ( ByteArrayInputStream bin = new ByteArrayInputStream( bout.toByteArray() ); ObjectInputStream in = new ObjectInputStream( bin ) )
+            {
+                o2.readExternal( in );
+            }
+        }
+
+        assertThat( o2.getName(), equalTo( "test-tag" ) );
+        assertThat( o2.getArches().toString(), equalTo( Arrays.asList( "x86_64", "i386" ).toString() ) );
+    }
+
+    @Test
+    public void testExternalizeKojiTaskInfo()
+            throws Exception
+    {
+        GetTaskResponse response = parseCapturedMessage( GetTaskResponse.class, "getTaskInfo-response.xml" );
+        KojiTaskInfo o1 = response.getTaskInfo();
+        KojiTaskInfo o2 = new KojiTaskInfo();
+
+        try ( ByteArrayOutputStream bout = new ByteArrayOutputStream(); ObjectOutputStream out = new ObjectOutputStream( bout ) )
+        {
+            o1.writeExternal( out );
+
+            out.close();
+
+            try ( ByteArrayInputStream bin = new ByteArrayInputStream( bout.toByteArray() ); ObjectInputStream in = new ObjectInputStream( bin ) )
+            {
+                o2.readExternal( in );
+            }
+        }
+
+        assertEquals( 0.20000000000000001D, o2.getWeight(), 0D );
+        assertEquals( 10211252, o2.getTaskId() );
+        assertEquals( new SimpleDateFormat( "yyyy-MM-dd HH:mm:ss" ).parse( "2015-12-09 01:12:25" ), o2.getCreateTime() );
+
+        List<Object> request = o2.getRequest();
+
+        assertEquals( "git://g.a.e.b.r.c/apache/cxf.git#154e3b7969fcf622aba3fb494b1b11f9215a9173", request.get( 0 ));
+        assertEquals( "jb-eap-7.0-rhel-7-maven-candidate", request.get( 1 ) );
+
+        Object obj = request.get( 2 );
+
+        assertTrue( obj instanceof Map );
+
+        Map<?, ?> m = (Map<?, ?>) obj;
+        List<?> goals = (List<?>) m.get( "goals" );
+
+        assertEquals( "install", goals.get( 0 ) );
+        assertEquals( "javadoc:aggregate-jar", goals.get( 1 ) );
+    }
+}


### PR DESCRIPTION
Implement Externalizable for the classes KojiArchiveInfo, KojiBuildInfo,
KojiTagInfo, and KojiTaskInfo. Also, add a unit test,
ExternalizableUtilsTest, for the added Externalizable functionality.