### PR TITLE
Infinite waiting when there are 0 imported files

### DIFF
--- a/src/main/java/com/redhat/red/build/koji/KojiClient.java
+++ b/src/main/java/com/redhat/red/build/koji/KojiClient.java
@@ -1577,9 +1577,9 @@ public class KojiClient
         Map<String, KojijiErrorInfo> uploadErrors = new HashMap<>();
         Set<UploadResponse> responses = new HashSet<>();
         int total = count.get();
-        do
+        while ( count.decrementAndGet() > 0 )
         {
-            logger.debug( "Waiting for {} uploads.", count.get() );
+            logger.debug( "Waiting for {} uploads.", count.get() + 1 );
 
             try
             {
@@ -1607,7 +1607,6 @@ public class KojiClient
                                                e.getMessage() );
             }
         }
-        while ( count.decrementAndGet() > 0 );
 
         return uploadErrors;
     }


### PR DESCRIPTION
If there are no files to import, in do-while when uploadService.take() is called then a blockingQueue inside is going to wait for some data to be submited, but with no files to import the result is that it will wait forever. I've introduced a simple fix that won't let the method be called in this case.

@jdcasey 