### PR TITLE
Instantiate uploadService per import call

### DIFF
--- a/src/main/java/com/redhat/red/build/koji/KojiClient.java
+++ b/src/main/java/com/redhat/red/build/koji/KojiClient.java
@@ -107,8 +107,6 @@ public class KojiClient
 
     private MetricRegistry metricRegistry;
 
-    private ExecutorCompletionService<KojiUploaderResult> uploadService;
-
     private KojiObjectMapper objectMapper;
 
     private KojiConfig config;
@@ -205,7 +203,6 @@ public class KojiClient
     public void setup()
                     throws KojiClientException
     {
-        uploadService = new ExecutorCompletionService<>( executorService );
         objectMapper = new KojiObjectMapper();
 
         logger.debug( "SETUP: Starting KojiClient for: " + config.getKojiURL() );
@@ -1702,6 +1699,7 @@ public class KojiClient
                                                                 String dirname, KojiSessionInfo session )
             throws KojiClientException
     {
+        ExecutorCompletionService<KojiUploaderResult> uploadService = new ExecutorCompletionService<>( executorService );
         AtomicInteger count = new AtomicInteger( 0 );
 
         if ( buildInfo != null )


### PR DESCRIPTION
We have been using a single ExecutorCompletionService for all file uploads. This
is a major problem because if we have two simultaneous import calls, they can get
crossed up waiting for the uploads to complete. The main reason is that they
only watch for a certain NUMBER of uploads to complete, not that SPECIFIC
uploads are completed.

To fix this, we either need to assign each upload an ID, then track their completion
via a map as we take() them from the uploadService...or we can instantiate an
uploadService for each import call, using the shared threadpool for all services.

The benefit of the latter approach is that we don't need overhead for generating
IDs (though we do use overhead to construct the service). Additionally, we don't
need to worry about what happens if we take() a Future that's actually related to
a different import call.

This should fix the race condition where uploads are still in progress at the
time when we make the RPC call to Koji to register the import.