### PR TITLE
Fix incorrect counting for failure while importing builds to Koji

### DIFF
--- a/src/main/java/com/redhat/red/build/koji/KojiClient.java
+++ b/src/main/java/com/redhat/red/build/koji/KojiClient.java
@@ -1732,7 +1732,7 @@ public class KojiClient
         Map<String, KojijiErrorInfo> uploadErrors = new HashMap<>();
         Set<UploadResponse> responses = new HashSet<>();
         int total = count.get();
-        while ( count.decrementAndGet() > 0 )
+        while ( count.getAndDecrement() > 0 )
         {
             logger.debug( "Waiting for {} uploads.", count.get() + 1 );
 


### PR DESCRIPTION
This is a silly mistake that counts wrong. It takes n-1 times where it should take n. This causes the method to returns sooner. The following import will fail if the last file is not yet uploaded to Koji. Fortunately, this does not impact the real import since the return value is only to indicate upload errors.