### PR TITLE
Fix NPM import support

### DIFF
--- a/src/main/java/com/redhat/red/build/koji/model/json/BuildDescription.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/BuildDescription.java
@@ -267,6 +267,11 @@ public class BuildDescription
             NpmExtraInfo npmExtraInfo = new NpmExtraInfo( nv.getName(), nv.getVersion().toString() );
             target.extraInfo.setNpmExtraInfo(npmExtraInfo);
 
+            if (target.extraInfo.getTypeInfo() == null) {
+                target.extraInfo.setTypeInfo(new TypeInfoExtraInfo());
+            }
+            target.extraInfo.getTypeInfo().setNpmTypeInfoExtraInfo( NpmTypeInfoExtraInfo.getInstance() );
+
             return this;
         }
 
@@ -289,8 +294,14 @@ public class BuildDescription
                 target.extraInfo = new BuildExtraInfo();
             }
 
-            TypeInfoExtraInfo typeInfo = new TypeInfoExtraInfo(new RemoteSourceFileExtraInfo(checksum));
-            target.extraInfo.setTypeInfo(typeInfo);
+            TypeInfoExtraInfo typeInfo = target.extraInfo.getTypeInfo();
+            if ( typeInfo == null )
+            {
+                target.extraInfo.setTypeInfo(new TypeInfoExtraInfo());
+                typeInfo = target.extraInfo.getTypeInfo();
+            }
+
+            typeInfo.setRemoteSourceFileExtraInfo(new RemoteSourceFileExtraInfo(checksum));
 
             return this;
         }

--- a/src/main/java/com/redhat/red/build/koji/model/json/BuildOutput.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/BuildOutput.java
@@ -276,7 +276,7 @@ public class BuildOutput
         public Builder withRemoteSourceFileInfoAndType( String checksum )
         {
             target.outputType = StandardOutputType.REMOTE_SOURCE_FILE.getName();
-            target.extraInfo = new FileExtraInfo( new TypeInfoExtraInfo(new RemoteSourceFileExtraInfo(checksum)) );
+            target.extraInfo = new FileExtraInfo( new TypeInfoExtraInfo(new RemoteSourceFileExtraInfo(checksum), null) );
 
             return this;
         }
@@ -384,7 +384,7 @@ public class BuildOutput
     {
         int result = getBuildrootId();
         result = 31 * result + ( getFilename() != null ? getFilename().hashCode() : 0 );
-        result = 31 * result + (int) ( getFileSize() ^ ( getFileSize() >>> 32 ) );
+        result = 31 * result + ( getFileSize() ^ ( getFileSize() >>> 32 ) );
         result = 31 * result + ( getArch() != null ? getArch().hashCode() : 0 );
         result = 31 * result + ( getChecksumType() != null ? getChecksumType().hashCode() : 0 );
         result = 31 * result + ( getChecksum() != null ? getChecksum().hashCode() : 0 );

--- a/src/main/java/com/redhat/red/build/koji/model/json/KojiJsonConstants.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/KojiJsonConstants.java
@@ -100,6 +100,8 @@ public final class KojiJsonConstants
 
     public static final String NPM_INFO = "npm";
 
+    public static final String NPM_TYPE_INFO = "npm";
+
     public static final String REMOTE_SOURCE_FILE = "remote-source-file";
 
     public static final String TYPEINFO = "typeinfo";

--- a/src/main/java/com/redhat/red/build/koji/model/json/NpmExtraInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/NpmExtraInfo.java
@@ -79,15 +79,18 @@ public class NpmExtraInfo
     @Override
     public boolean equals( Object o )
     {
-        if ( this == o )
+        if ( this == o ) {
             return true;
-        if ( o == null || getClass() != o.getClass() )
+        }
+        if ( o == null || getClass() != o.getClass() ) {
             return false;
+        }
 
         NpmExtraInfo that = (NpmExtraInfo) o;
 
-        if ( !name.equals( that.name ) )
+        if ( !name.equals( that.name ) ) {
             return false;
+        }
         return version.equals( that.version );
 
     }

--- a/src/main/java/com/redhat/red/build/koji/model/json/NpmTypeInfoExtraInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/NpmTypeInfoExtraInfo.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc. (jcasey@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.red.build.koji.model.json;
+
+import org.commonjava.rwx.anno.StructPart;
+
+/**
+ * Created by pkocandr on 06/22/21
+ */
+@StructPart
+public class NpmTypeInfoExtraInfo
+{
+    private static NpmTypeInfoExtraInfo instance;
+
+    public NpmTypeInfoExtraInfo()
+    {
+    }
+
+    public static NpmTypeInfoExtraInfo getInstance() {
+        if (instance == null)
+        {
+            // if instance is null, initialize
+            instance = new NpmTypeInfoExtraInfo();
+        }
+        return instance;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "NpmTypeInfoExtraInfo{}";
+    }
+}

--- a/src/main/java/com/redhat/red/build/koji/model/json/TypeInfoExtraInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/TypeInfoExtraInfo.java
@@ -21,6 +21,7 @@ import org.commonjava.rwx.anno.StructPart;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import static com.redhat.red.build.koji.model.json.KojiJsonConstants.NPM_TYPE_INFO;
 import static com.redhat.red.build.koji.model.json.KojiJsonConstants.REMOTE_SOURCE_FILE;
 
 /**
@@ -33,9 +34,15 @@ public class TypeInfoExtraInfo
     @DataKey( REMOTE_SOURCE_FILE )
     private RemoteSourceFileExtraInfo remoteSourceFileExtraInfo;
 
+    @JsonProperty( NPM_TYPE_INFO )
+    @DataKey( NPM_TYPE_INFO )
+    private NpmTypeInfoExtraInfo npmTypeInfoExtraInfo;
+
 
     @JsonCreator
-    public TypeInfoExtraInfo(@JsonProperty( REMOTE_SOURCE_FILE ) RemoteSourceFileExtraInfo typeInfo)
+    public TypeInfoExtraInfo(
+            @JsonProperty(REMOTE_SOURCE_FILE) RemoteSourceFileExtraInfo typeInfo,
+            @JsonProperty(NPM_TYPE_INFO) Object npm)
     {
         this.remoteSourceFileExtraInfo = typeInfo;
     }
@@ -54,6 +61,16 @@ public class TypeInfoExtraInfo
         this.remoteSourceFileExtraInfo = remoteSourceFileExtraInfo;
     }
 
+    public NpmTypeInfoExtraInfo getNpmTypeInfoExtraInfo()
+    {
+        return npmTypeInfoExtraInfo;
+    }
+
+    public void setNpmTypeInfoExtraInfo(NpmTypeInfoExtraInfo npmTypeInfoExtraInfo)
+    {
+        this.npmTypeInfoExtraInfo = npmTypeInfoExtraInfo;
+    }
+
     @Override
     public boolean equals( Object o )
     {
@@ -68,20 +85,24 @@ public class TypeInfoExtraInfo
 
         TypeInfoExtraInfo that = (TypeInfoExtraInfo) o;
 
-        return getRemoteSourceFileExtraInfo() != null ? getRemoteSourceFileExtraInfo().equals( that.getRemoteSourceFileExtraInfo() ) : that.getRemoteSourceFileExtraInfo() == null;
+        return getRemoteSourceFileExtraInfo() != null ? getRemoteSourceFileExtraInfo().equals( that.getRemoteSourceFileExtraInfo() ) : that.getRemoteSourceFileExtraInfo() == null
+                && getNpmTypeInfoExtraInfo() != null ? getNpmTypeInfoExtraInfo().equals( that.getNpmTypeInfoExtraInfo() ) : that.getNpmTypeInfoExtraInfo() == null;
 
     }
 
     @Override
     public int hashCode()
     {
-        int result = getRemoteSourceFileExtraInfo() != null ? getRemoteSourceFileExtraInfo().hashCode() : 0;
+        int result = getRemoteSourceFileExtraInfo() == null ? 0 : getRemoteSourceFileExtraInfo().hashCode();
+        result = 31 * result + (getNpmTypeInfoExtraInfo() == null ? 0 : getNpmTypeInfoExtraInfo().hashCode());
         return result;
     }
 
     @Override
     public String toString()
     {
-        return "TypeInfoExtraInfo{" + "remoteSourceFileExtraInfo='" + remoteSourceFileExtraInfo + "'}";
+        return "TypeInfoExtraInfo{"
+                + "remoteSourceFileExtraInfo='" + remoteSourceFileExtraInfo + "', "
+                + "npmTypeInfoExtraInfo='" + npmTypeInfoExtraInfo + "'}";
     }
 }


### PR DESCRIPTION
Imports of NPM builds from PNC to Brew end with
```com.redhat.red.build.koji.KojiClientException: Failed to execute content-generator import. Reason: {faultCode=1000, faultString=No typeinfo for: keycloak-connect/-/keycloak-connect-9.0.1-dev-redhat-00011.tgz}```

It should be fixed by adding empty dict with build type in extra.typeinfo, something like `'typeinfo': {'npm': {}}`.