### PR TITLE
Fixed the getPackageId method

### DIFF
--- a/src/main/java/com/redhat/red/build/koji/KojiClient.java
+++ b/src/main/java/com/redhat/red/build/koji/KojiClient.java
@@ -552,7 +552,7 @@ public class KojiClient
             throws KojiClientException
     {
         return doXmlRpcAndThrow( () -> {
-            IdResponse response = xmlrpcClient.call( new GetTagIdRequest( packageName ), IdResponse.class,
+            IdResponse response = xmlrpcClient.call( new GetPackageIdRequest( packageName ), IdResponse.class,
                                                      sessionUrlBuilder( session ), STANDARD_REQUEST_MODIFIER );
 
             return response == null ? null : response.getId();


### PR DESCRIPTION
Hello all. First, thank you for the Java client!

I noticed that the `getPackageId` method was using `GetTagIdRequest` instead of the `GetPackageIdRequest` request type. I switched it over and it now returns the package ID for a given package name. I did not include them, but I can add tests for this if you would like.