### PR TITLE
Apply the AnythingToStringConverter on epoch

### DIFF
--- a/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiRpmInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiRpmInfo.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 
+import com.redhat.red.build.koji.model.converter.AnythingToStringConverter;
 import org.commonjava.rwx.anno.Converter;
 import org.commonjava.rwx.anno.DataKey;
 import org.commonjava.rwx.anno.StructPart;
@@ -57,6 +58,7 @@ public class KojiRpmInfo
     private String arch;
 
     @DataKey( "epoch" )
+    @Converter( AnythingToStringConverter.class )
     private String epoch;
 
     @DataKey( "payloadhash" )


### PR DESCRIPTION
Hello all! 

I've noticed that the epoch pulled from Koji can be an `Integer` (as is the case for certain `moodle` RPMs). I've applied the `AnythingToStringConverter` to the epoch key and that seems to have done the trick. I did not include them, but I can add tests around this functionality if you would like.

