### PR TITLE
Remove parallelism from uploadForImport

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'maven' }
+    agent { label 'maven-jdk11' }
     stages {
         stage('Prepare') {
             steps {

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <rwxVersion>2.3</rwxVersion>
         <httpcVersion>4.4</httpcVersion>
         <atlasVersion>1.0.0</atlasVersion>
-        <mockitoVersion>2.7.20</mockitoVersion>
+        <mockitoVersion>2.22.0</mockitoVersion>
         <kerbyVersion>2.0.1</kerbyVersion>
         <o11yphantVersion>1.0</o11yphantVersion>
 


### PR DESCRIPTION
The method uploadForImport is not thread-safe. Uploading files in parallel much be done in sub-sessions. Otherwise, it may fail on "requests are received out of sequence" if the last call for the session has higher callnum than prev ones. Adding sub-session is not trivial and spawning a sub-session involves an additional remote call for each upload. Until we could add and test the sub-session approach, I remove the parallelism and upload the artifacts in sequence.

There are some existing Import IT tests that can cover this change.

See [RHELBLD-11817](https://issues.redhat.com/browse/RHELBLD-11817) and [NCLSUP-816](https://issues.redhat.com/browse/NCLSUP-816) for more information.