### PR TITLE
Add retries for network exceptions

### DIFF
--- a/src/main/java/com/redhat/red/build/koji/http/httpclient4/HC4SyncObjectClient.java
+++ b/src/main/java/com/redhat/red/build/koji/http/httpclient4/HC4SyncObjectClient.java
@@ -68,7 +68,7 @@ public class HC4SyncObjectClient
     {
         if ( metricRegistry == null )
         {
-            return doCall( request, responseType, urlBuilder, requestModifier );
+            return RetryUtils.withRetry( () -> doCall(request, responseType, urlBuilder, requestModifier) );
         }
 
         // Apply global and per request metric
@@ -77,7 +77,7 @@ public class HC4SyncObjectClient
         final Timer.Context requestTimerContext = metricRegistry.timer( name( request.getClass(), "call" ) ).time();
         try
         {
-            return doCall( request, responseType, urlBuilder, requestModifier );
+            return RetryUtils.withRetry( () -> doCall(request, responseType, urlBuilder, requestModifier) );
         }
         finally
         {

--- a/src/main/java/com/redhat/red/build/koji/http/httpclient4/RetryUtils.java
+++ b/src/main/java/com/redhat/red/build/koji/http/httpclient4/RetryUtils.java
@@ -1,0 +1,63 @@
+package com.redhat.red.build.koji.http.httpclient4;
+
+import org.commonjava.rwx.error.XmlRpcException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.ConnectException;
+
+public class RetryUtils
+{
+    private static final Logger log = LoggerFactory.getLogger( RetryUtils.class );
+
+    public static final int DEFAULT_RETRY_COUNT = 3;
+
+    public static final long DEFAULT_WAIT_SECONDS = 10;
+
+    public interface CallToRetry<R>
+    {
+        R process() throws XmlRpcException;
+    }
+
+    public static <T> T withRetry( CallToRetry call ) throws XmlRpcException
+    {
+        return withRetry( DEFAULT_RETRY_COUNT, DEFAULT_WAIT_SECONDS, call );
+    }
+
+    public static <T> T withRetry( int retryCount, long interval, CallToRetry call ) throws XmlRpcException
+    {
+        int count = 0;
+        while ( true )
+        {
+            try
+            {
+                return (T) call.process();
+            }
+            catch ( XmlRpcException e )
+            {
+                if ( ++count > retryCount )
+                {
+                    throw e;
+                }
+
+                if ( e.getCause() instanceof ConnectException )
+                {
+                    log.info( "ConnectException {}/{}, Waiting for {} second(s) before next retry ...", e.getCause().getClass(), e.getCause().getMessage(), interval );
+                    try
+                    {
+                        Thread.sleep( interval * 1000l );
+                    }
+                    catch ( InterruptedException ex )
+                    {
+                        throw new RuntimeException( ex );
+                    }
+                }
+                else
+                {
+                    throw e;
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
CloseableHttpClient has the default retry mechanism, but it just retry with the idempotent request, that means it does not work for HttpPost, and all of the request sending to kojiji is HttpPost,  adding this retry here just for `ConnectionException`, we can extend it further if needed. 