### PR TITLE
Fix Jenkinsfile no need Archive stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,12 +21,5 @@ pipeline {
                 sh 'mvn help:effective-settings -B -V clean deploy -e'
             }
         }
-        stage('Archive') {
-            when { branch 'master' }
-            steps {
-                echo "Archive"
-                archiveArtifacts artifacts: "$artifact_glob", fingerprint: true
-            }
-        }
     }
 }


### PR DESCRIPTION
The merge build 'archive' stage failed with 'groovy.lang.MissingPropertyException: No such property: artifact_glob ...' @ligangty It seems you add the stage in https://github.com/release-engineering/kojiji/pull/151
Not sure the context but I think Kojiji don't need archive. I remove it to fix the merge build.