### PR TITLE
Stop to override the NPM build info with buildType info

### DIFF
--- a/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiBuildTypeInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiBuildTypeInfo.java
@@ -163,10 +163,11 @@ public class KojiBuildTypeInfo
             }
             else if ( obj instanceof KojiNpmBuildInfo )
             {
-                KojiNpmBuildInfo npm = (KojiNpmBuildInfo) obj;
-                buildInfo.setId( npm.getBuildId() );
-                buildInfo.setName( npm.getName() );
-                buildInfo.setVersion( npm.getVersion() );
+                // TODO Comment this until brew support to return the buildInfo for NPM builds
+                // KojiNpmBuildInfo npm = (KojiNpmBuildInfo) obj;
+                // buildInfo.setId( npm.getBuildId() );
+                // buildInfo.setName( npm.getName() );
+                // buildInfo.setVersion( npm.getVersion() );
             }
             else if ( obj instanceof KojiRpmBuildInfo )
             {


### PR DESCRIPTION
The brew side does not return the full NPM buildType info as the following, it caused that the original build info will be overwritten by the empty info. So let's comment it out until brew support that in future.  
`
$ koji --noauth call getBuildType 2508881

{'npm': {}} 
`