### PR TITLE
Change type of btype from string to proper enum

### DIFF
--- a/src/main/java/com/redhat/red/build/koji/KojiClient.java
+++ b/src/main/java/com/redhat/red/build/koji/KojiClient.java
@@ -935,7 +935,7 @@ public class KojiClient
     public void enrichArchiveTypeInfo( List<KojiArchiveInfo> archives, KojiSessionInfo session )
             throws KojiClientException
     {
-        Map<String, List<KojiArchiveInfo>> buildTypeMap = archives.stream().collect( Collectors.groupingBy( KojiArchiveInfo::getBuildType ) );
+        Map<KojiBtype, List<KojiArchiveInfo>> buildTypeMap = archives.stream().collect( Collectors.groupingBy( KojiArchiveInfo::getBuildType ) );
 
         final AtomicReference<KojiClientException> err = new AtomicReference<>();
 
@@ -945,7 +945,7 @@ public class KojiClient
             {
                 switch ( buildType )
                 {
-                    case "maven":
+                    case maven:
                         List<KojiMavenArchiveInfo> mavenArchiveInfos =
                                         multiCall( Constants.GET_MAVEN_ARCHIVE, archiveIds, KojiMavenArchiveInfo.class,
                                                    session );
@@ -954,7 +954,7 @@ public class KojiClient
                             archiveInfos.get( i ).addMavenArchiveInfo( mavenArchiveInfos.get( i ) );
                         }
                         break;
-                    case "image":
+                    case image:
                         List<KojiImageArchiveInfo> imageArchiveInfos =
                                         multiCall( Constants.GET_IMAGE_ARCHIVE, archiveIds, KojiImageArchiveInfo.class,
                                                    session );
@@ -963,7 +963,7 @@ public class KojiClient
                             archiveInfos.get( i ).addImageArchiveInfo( imageArchiveInfos.get( i ) );
                         }
                         break;
-                    case "win":
+                    case win:
                         List<KojiWinArchiveInfo> winArchiveInfos =
                                         multiCall( Constants.GET_WIN_ARCHIVE, archiveIds, KojiWinArchiveInfo.class,
                                                    session );
@@ -972,8 +972,6 @@ public class KojiClient
                             archiveInfos.get( i ).addWinArchiveInfo( winArchiveInfos.get( i ) );
                         }
                         break;
-                    default:
-                        logger.warn( "Unknown archive build type: {}", buildType );
                 }
             }
             catch ( KojiClientException e )

--- a/src/main/java/com/redhat/red/build/koji/model/converter/KojiBtypeConverter.java
+++ b/src/main/java/com/redhat/red/build/koji/model/converter/KojiBtypeConverter.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc. (jcasey@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.red.build.koji.model.converter;
+
+import com.redhat.red.build.koji.model.xmlrpc.KojiBtype;
+import org.commonjava.rwx.core.Converter;
+
+public class KojiBtypeConverter
+                implements Converter<KojiBtype>
+{
+    @Override
+    public KojiBtype parse( Object object )
+    {
+        return KojiBtype.fromString( object.toString() );
+    }
+
+    @Override
+    public Object render( KojiBtype value )
+    {
+        if ( value == null )
+        {
+            return null;
+        }
+
+        return value.name();
+    }
+}

--- a/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiBtype.java
+++ b/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiBtype.java
@@ -1,0 +1,34 @@
+package com.redhat.red.build.koji.model.xmlrpc;
+
+public enum KojiBtype
+{
+    rpm,
+    maven,
+    win,
+    image,
+    npm;
+
+    KojiBtype()
+    {
+
+    }
+
+    public static KojiBtype fromString( String name )
+    {
+        for ( KojiBtype btype : values() )
+        {
+            if ( btype.name().equals( name ) )
+            {
+                return btype;
+            }
+        }
+
+        throw new IllegalArgumentException( "Unknown build type: " + name );
+    }
+
+    @Override
+    public String toString()
+    {
+        return name();
+    }
+}

--- a/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiBuildTypeInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiBuildTypeInfo.java
@@ -19,6 +19,7 @@ import org.commonjava.rwx.anno.DataKey;
 import org.commonjava.rwx.anno.StructPart;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @StructPart
@@ -50,7 +51,7 @@ public class KojiBuildTypeInfo
     private KojiNpmBuildInfo npm;
 
     // a build may contain more than one types, e.g., maven and rpm
-    private List<String> names = new ArrayList<>(  );
+    private List<KojiBtype> names = new ArrayList<>(  );
 
     private List<Object> buildInfoList = new ArrayList<>(  );
 
@@ -62,7 +63,7 @@ public class KojiBuildTypeInfo
     public void setNpm( KojiNpmBuildInfo npm )
     {
         this.npm = npm;
-        names.add( NPM );
+        names.add( KojiBtype.npm );
         buildInfoList.add( npm );
     }
 
@@ -74,7 +75,7 @@ public class KojiBuildTypeInfo
     public void setRpm( KojiRpmBuildInfo rpm )
     {
         this.rpm = rpm;
-        names.add( RPM );
+        names.add( KojiBtype.rpm );
         buildInfoList.add( rpm );
     }
 
@@ -86,7 +87,7 @@ public class KojiBuildTypeInfo
     public void setMaven( KojiMavenBuildInfo maven )
     {
         this.maven = maven;
-        names.add( MAVEN );
+        names.add( KojiBtype.maven );
         buildInfoList.add( maven );
     }
 
@@ -98,7 +99,7 @@ public class KojiBuildTypeInfo
     public void setWin( KojiWinBuildInfo win )
     {
         this.win = win;
-        names.add( WIN );
+        names.add( KojiBtype.win );
         buildInfoList.add( win );
     }
 
@@ -110,13 +111,13 @@ public class KojiBuildTypeInfo
     public void setImage( KojiImageBuildInfo image )
     {
         this.image = image;
-        names.add( IMAGE );
+        names.add( KojiBtype.image );
         buildInfoList.add( image );
     }
 
-    public List<String> getNames()
+    public List<KojiBtype> getNames()
     {
-        return names;
+        return Collections.unmodifiableList( names );
     }
 
     /**
@@ -181,7 +182,7 @@ public class KojiBuildTypeInfo
 
     public List<Object> getBuildInfo()
     {
-        return buildInfoList;
+        return Collections.unmodifiableList( buildInfoList );
     }
 
     @Override

--- a/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiChecksumType.java
+++ b/src/main/java/com/redhat/red/build/koji/model/xmlrpc/KojiChecksumType.java
@@ -21,8 +21,9 @@ public enum KojiChecksumType
     sha1   ( 1, "SHA-1" ),
     sha256 ( 2, "SHA-256" );
 
-    private Integer value;
-    private String algorithm;
+    private final Integer value;
+
+    private final String algorithm;
 
     private KojiChecksumType( int value, String algorithm )
     {
@@ -40,7 +41,7 @@ public enum KojiChecksumType
         return algorithm;
     }
 
-    public static KojiChecksumType fromInteger( Integer value )
+    public static KojiChecksumType fromInteger( int value )
     {
         for ( KojiChecksumType checksum : values() )
         {

--- a/src/test/java/com/redhat/red/build/koji/it/ExternalGetBuildInfoIT.java
+++ b/src/test/java/com/redhat/red/build/koji/it/ExternalGetBuildInfoIT.java
@@ -21,6 +21,7 @@ import com.redhat.red.build.koji.model.xmlrpc.KojiSessionInfo;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static com.redhat.red.build.koji.model.xmlrpc.KojiBtype.rpm;
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -61,6 +62,6 @@ public class ExternalGetBuildInfoIT
         client.logout(session);
 
         assertThat( info, notNullValue() );
-        assertTrue( info.getTypeNames().contains( "rpm" ) );
+        assertTrue( info.getTypeNames().contains( rpm ) );
     }
 }

--- a/src/test/java/com/redhat/red/build/koji/model/util/ExternalizableUtilsTest.java
+++ b/src/test/java/com/redhat/red/build/koji/model/util/ExternalizableUtilsTest.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static com.redhat.red.build.koji.model.xmlrpc.KojiBtype.maven;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -69,7 +70,7 @@ public class ExternalizableUtilsTest
         }
 
         assertThat( o2.getArtifactId(), equalTo( "netty-all" ) );
-        assertThat( o2.getBuildType(), equalTo( "maven" ) );
+        assertThat( o2.getBuildType(), equalTo( maven ) );
         assertThat( o2.getBuildTypeId(), equalTo( 2 ) );
         assertThat( o2.getBuildId(), equalTo( 558964 ) );
         assertThat( o2.getBuildrootId(), equalTo( null ) );

--- a/src/test/java/com/redhat/red/build/koji/model/xmlrpc/messages/GetArchiveResponseTest.java
+++ b/src/test/java/com/redhat/red/build/koji/model/xmlrpc/messages/GetArchiveResponseTest.java
@@ -19,6 +19,7 @@ import com.redhat.red.build.koji.model.xmlrpc.KojiArchiveInfo;
 import com.redhat.red.build.koji.model.xmlrpc.KojiChecksumType;
 import org.junit.Test;
 
+import static com.redhat.red.build.koji.model.xmlrpc.KojiBtype.maven;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -34,7 +35,7 @@ public class GetArchiveResponseTest
         KojiArchiveInfo archiveInfo = parsed.getArchiveInfo();
 
         assertThat( archiveInfo.getArtifactId(), equalTo( "netty-all" ) );
-        assertThat( archiveInfo.getBuildType(), equalTo( "maven" ) );
+        assertThat( archiveInfo.getBuildType(), equalTo( maven ) );
         assertThat( archiveInfo.getBuildTypeId(), equalTo( 2 ) );
         assertThat( archiveInfo.getBuildId(), equalTo( 558964 ) );
         assertThat( archiveInfo.getBuildrootId(), equalTo( null ) );
@@ -59,7 +60,7 @@ public class GetArchiveResponseTest
         GetArchiveResponse resp = new GetArchiveResponse();
         KojiArchiveInfo archiveInfo = new KojiArchiveInfo();
         archiveInfo.setArtifactId( "netty-all" );
-        archiveInfo.setBuildType( "maven" );
+        archiveInfo.setBuildType( maven );
         archiveInfo.setBuildTypeId( 2 );
         archiveInfo.setBuildId( 558964 );
         archiveInfo.setBuildrootId( null );


### PR DESCRIPTION
This is a breaking change, but I feel like it's an improvement. It looks like some PNC tools are abusing this field to add types that Koji does not support ("gradle", "sbt"), and this change will prevent that.

I will need a new release.
