### PR TITLE
Add better support for images

### DIFF
--- a/src/main/java/com/redhat/red/build/koji/http/httpclient4/RetryUtils.java
+++ b/src/main/java/com/redhat/red/build/koji/http/httpclient4/RetryUtils.java
@@ -23,7 +23,7 @@ import java.net.ConnectException;
 
 public class RetryUtils
 {
-    private static final Logger log = LoggerFactory.getLogger( RetryUtils.class );
+    private static final Logger logger = LoggerFactory.getLogger( RetryUtils.class );
 
     public static final int DEFAULT_RETRY_COUNT = 3;
 
@@ -57,7 +57,7 @@ public class RetryUtils
 
                 if ( e.getCause() instanceof ConnectException )
                 {
-                    log.info( "ConnectException {}/{}, Waiting for {} second(s) before next retry ...", e.getCause().getClass(), e.getCause().getMessage(), interval );
+                    logger.info( "ConnectException {}/{}, Waiting for {} second(s) before next retry ...", e.getCause().getClass(), e.getCause().getMessage(), interval );
                     try
                     {
                         Thread.sleep( interval * 1000l );

--- a/src/main/java/com/redhat/red/build/koji/model/json/BuildExtraInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/BuildExtraInfo.java
@@ -35,7 +35,9 @@ import static com.redhat.red.build.koji.model.json.KojiJsonConstants.IMAGE_INFO;
 import static com.redhat.red.build.koji.model.json.KojiJsonConstants.IMPORT_INITIATOR;
 import static com.redhat.red.build.koji.model.json.KojiJsonConstants.MAVEN_INFO;
 import static com.redhat.red.build.koji.model.json.KojiJsonConstants.NPM_INFO;
+import static com.redhat.red.build.koji.model.json.KojiJsonConstants.OSBS_BUILD;
 import static com.redhat.red.build.koji.model.json.KojiJsonConstants.SCM_TAG;
+import static com.redhat.red.build.koji.model.json.KojiJsonConstants.SUBMITTER;
 import static com.redhat.red.build.koji.model.json.KojiJsonConstants.TYPEINFO;
 
 /**
@@ -45,6 +47,14 @@ import static com.redhat.red.build.koji.model.json.KojiJsonConstants.TYPEINFO;
 @JsonInclude( Include.NON_NULL )
 public class BuildExtraInfo
 {
+    @JsonProperty(  CONTAINER_KOJI_TASK_ID  )
+    @DataKey( CONTAINER_KOJI_TASK_ID )
+    private Integer containerKojiTaskId;
+
+    @JsonProperty( FILESYSTEM_KOJI_TASK_ID )
+    @DataKey( FILESYSTEM_KOJI_TASK_ID )
+    private Integer filesystemKojiTaskId;
+
     @JsonProperty( MAVEN_INFO )
     @DataKey( MAVEN_INFO )
     private MavenExtraInfo mavenExtraInfo;
@@ -77,17 +87,17 @@ public class BuildExtraInfo
     @DataKey( SCM_TAG )
     private String scmTag;
 
+    @JsonProperty( OSBS_BUILD )
+    @DataKey( OSBS_BUILD )
+    private OsbsBuildExtraInfo osbsBuild;
+
+    @JsonProperty( SUBMITTER )
+    @DataKey( SUBMITTER )
+    private String submitter;
+
     @JsonProperty( TYPEINFO )
     @DataKey( TYPEINFO )
     private TypeInfoExtraInfo typeInfo;
-
-    @JsonProperty( CONTAINER_KOJI_TASK_ID )
-    @DataKey( CONTAINER_KOJI_TASK_ID )
-    private Integer containerKojiTaskId;
-
-    @JsonProperty( FILESYSTEM_KOJI_TASK_ID )
-    @DataKey( FILESYSTEM_KOJI_TASK_ID )
-    private Integer filesystemKojiTaskId;
 
     public BuildExtraInfo(){}
 
@@ -136,11 +146,13 @@ public class BuildExtraInfo
         this.mavenExtraInfo = mavenExtraInfo;
     }
 
-    public NpmExtraInfo getNpmExtraInfo() {
+    public NpmExtraInfo getNpmExtraInfo()
+    {
         return npmExtraInfo;
     }
 
-    public void setNpmExtraInfo(NpmExtraInfo npmExtraInfo) {
+    public void setNpmExtraInfo( NpmExtraInfo npmExtraInfo )
+    {
         this.npmExtraInfo = npmExtraInfo;
     }
 
@@ -154,19 +166,23 @@ public class BuildExtraInfo
         this.externalBuildId = externalBuildId;
     }
 
-    public String getBuildSystem() {
+    public String getBuildSystem()
+    {
         return buildSystem;
     }
 
-    public void setBuildSystem(String buildSystem) {
+    public void setBuildSystem( String buildSystem )
+    {
         this.buildSystem = buildSystem;
     }
 
-    public String getExternalBuildUrl() {
+    public String getExternalBuildUrl()
+    {
         return externalBuildUrl;
     }
 
-    public void setExternalBuildUrl(String externalBuildUrl) {
+    public void setExternalBuildUrl( String externalBuildUrl )
+    {
         this.externalBuildUrl = externalBuildUrl;
     }
 
@@ -220,6 +236,26 @@ public class BuildExtraInfo
         return filesystemKojiTaskId;
     }
 
+    public OsbsBuildExtraInfo getOsbsBuild()
+    {
+        return osbsBuild;
+    }
+
+    public void setOsbsBuild( OsbsBuildExtraInfo osbsBuild )
+    {
+        this.osbsBuild = osbsBuild;
+    }
+
+    public String getSubmitter()
+    {
+        return submitter;
+    }
+
+    public void setSubmitter( String submitter )
+    {
+        this.submitter = submitter;
+    }
+
     @Override
     public boolean equals( Object o )
     {
@@ -228,19 +264,22 @@ public class BuildExtraInfo
             return false;
         }
 
-        BuildExtraInfo that = (BuildExtraInfo) o;
-        return Objects.equals( mavenExtraInfo, that.mavenExtraInfo) && Objects.equals(npmExtraInfo, that.npmExtraInfo) && Objects.equals(imageExtraInfo, that.imageExtraInfo) && Objects.equals(externalBuildId, that.externalBuildId) && Objects.equals(buildSystem, that.buildSystem) && Objects.equals(externalBuildUrl, that.externalBuildUrl) && Objects.equals(importInitiator, that.importInitiator) && Objects.equals(scmTag, that.scmTag) && Objects.equals(typeInfo, that.typeInfo) && Objects.equals(containerKojiTaskId, that.containerKojiTaskId) && Objects.equals(filesystemKojiTaskId, that.filesystemKojiTaskId );
+        BuildExtraInfo that = (BuildExtraInfo ) o;
+        return Objects.equals( mavenExtraInfo, that.mavenExtraInfo ) && Objects.equals( npmExtraInfo, that.npmExtraInfo ) && Objects.equals( imageExtraInfo, that.imageExtraInfo ) && Objects.equals( externalBuildId, that.externalBuildId ) && Objects.equals( buildSystem, that.buildSystem ) && Objects.equals( externalBuildUrl, that.externalBuildUrl ) && Objects.equals( importInitiator, that.importInitiator ) && Objects.equals( scmTag, that.scmTag ) && Objects.equals( typeInfo, that.typeInfo ) && Objects.equals( containerKojiTaskId, that.containerKojiTaskId ) && Objects.equals( filesystemKojiTaskId, that.filesystemKojiTaskId ) && Objects.equals( osbsBuild, that.osbsBuild ) && Objects.equals( submitter, that.submitter );
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash( mavenExtraInfo, npmExtraInfo, imageExtraInfo, externalBuildId, buildSystem, externalBuildUrl, importInitiator, scmTag, typeInfo, containerKojiTaskId, filesystemKojiTaskId );
+        return Objects.hash( mavenExtraInfo, npmExtraInfo, imageExtraInfo, externalBuildId, buildSystem, externalBuildUrl, importInitiator, scmTag, typeInfo, containerKojiTaskId, filesystemKojiTaskId, osbsBuild, submitter );
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return "BuildExtraInfo{" +
-                "mavenExtraInfo=" + mavenExtraInfo +
+                "containerKojiTaskId=" + containerKojiTaskId +
+                ", filesystemKojiTaskId=" + filesystemKojiTaskId +
+                ", mavenExtraInfo=" + mavenExtraInfo +
                 ", npmExtraInfo=" + npmExtraInfo +
                 ", imageExtraInfo=" + imageExtraInfo +
                 ", externalBuildId='" + externalBuildId + '\'' +
@@ -249,8 +288,8 @@ public class BuildExtraInfo
                 ", importInitiator='" + importInitiator + '\'' +
                 ", scmTag='" + scmTag + '\'' +
                 ", typeInfo=" + typeInfo +
-                ", containerKojiTaskId=" + containerKojiTaskId +
-                ", filesystemKojiTaskId=" + filesystemKojiTaskId +
+                ", osbsBuild=" + osbsBuild +
+                ", submitter='" + submitter + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/redhat/red/build/koji/model/json/BuildOutput.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/BuildOutput.java
@@ -282,10 +282,10 @@ public class BuildOutput
             return this;
         }
 
-        public Builder withRemoteSourcesInfoAndType( List<String> archives, String name, String url )
+        public Builder withRemoteSourcesInfoAndType( List<RemoteSourcesExtraInfo> sourcesExtraInfo )
         {
             target.outputType = StandardOutputType.remote_sources.getName();
-            target.extraInfo = new FileExtraInfo( new TypeInfoExtraInfo( new RemoteSourcesExtraInfo( archives, name, url ) ) );
+            target.extraInfo = new FileExtraInfo( new TypeInfoExtraInfo( sourcesExtraInfo ) );
 
             return this;
         }
@@ -293,7 +293,7 @@ public class BuildOutput
         public Builder withRemoteSourceFileInfoAndType( String checksum )
         {
             target.outputType = StandardOutputType.REMOTE_SOURCE_FILE.getName();
-            target.extraInfo = new FileExtraInfo( new TypeInfoExtraInfo( new RemoteSourceFileExtraInfo( checksum ), null ) );
+            target.extraInfo = new FileExtraInfo( new TypeInfoExtraInfo( new RemoteSourceFileExtraInfo( checksum ), null, null ) );
             return this;
         }
 

--- a/src/main/java/com/redhat/red/build/koji/model/json/FileExtraInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/FileExtraInfo.java
@@ -58,7 +58,7 @@ public class FileExtraInfo
         this.typeInfo = typeInfo;
     }
 
-    public FileExtraInfo( @JsonProperty( TYPEINFO ) TypeInfoExtraInfo typeInfo)
+    public FileExtraInfo( @JsonProperty( TYPEINFO ) TypeInfoExtraInfo typeInfo )
     {
         this.typeInfo = typeInfo;
     }

--- a/src/main/java/com/redhat/red/build/koji/model/json/IcmExtraInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/IcmExtraInfo.java
@@ -16,6 +16,7 @@
 package com.redhat.red.build.koji.model.json;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.redhat.red.build.koji.model.converter.StringListConverter;
 import org.commonjava.rwx.anno.Converter;
@@ -27,13 +28,9 @@ import java.util.Objects;
 
 import static com.redhat.red.build.koji.model.json.KojiJsonConstants.ARCHIVES;
 import static com.redhat.red.build.koji.model.json.KojiJsonConstants.NAME;
-import static com.redhat.red.build.koji.model.json.KojiJsonConstants.URL;
 
-/**
- * Created by dwalluck on 2025-04-09.
- */
 @StructPart
-public class RemoteSourcesExtraInfo
+public class IcmExtraInfo
 {
     @JsonProperty( ARCHIVES )
     @DataKey( ARCHIVES )
@@ -44,21 +41,16 @@ public class RemoteSourcesExtraInfo
     @DataKey( NAME )
     private String name;
 
-    @JsonProperty( URL )
-    @DataKey( URL )
-    private String url;
-
-    public RemoteSourcesExtraInfo()
+    public IcmExtraInfo()
     {
 
     }
 
     @JsonCreator
-    public RemoteSourcesExtraInfo( @JsonProperty( ARCHIVES ) List<String> archives, @JsonProperty( NAME ) String name, @JsonProperty( URL ) String url )
+    public IcmExtraInfo( @JsonProperty( ARCHIVES ) List<String> archives, @JsonProperty( NAME ) String name )
     {
         this.archives = archives;
         this.name = name;
-        this.url = url;
     }
 
     public List<String> getArchives()
@@ -81,16 +73,6 @@ public class RemoteSourcesExtraInfo
         this.name = name;
     }
 
-    public String getUrl()
-    {
-        return url;
-    }
-
-    public void setUrl( String url )
-    {
-        this.url = url;
-    }
-
     @Override
     public boolean equals( Object o )
     {
@@ -99,19 +81,22 @@ public class RemoteSourcesExtraInfo
             return false;
         }
 
-        RemoteSourcesExtraInfo that = (RemoteSourcesExtraInfo) o;
-        return Objects.equals( archives, that.archives ) && Objects.equals( name, that.name ) && Objects.equals( url, that.url );
+        IcmExtraInfo that = (IcmExtraInfo) o;
+        return Objects.equals( archives, that.archives ) && Objects.equals( name, that.name );
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( archives, name, url );
+        return Objects.hash( archives, name );
     }
 
     @Override
     public String toString()
     {
-        return "RemoteSourcesExtraInfo{archives=" + archives + ", name='" + name + '\'' + ", url='" + url + "'}";
+        return "IcmExtraInfo{" +
+                "archives=" + archives +
+                ", name='" + name + '\'' +
+                '}';
     }
 }

--- a/src/main/java/com/redhat/red/build/koji/model/json/ImageExtraInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/ImageExtraInfo.java
@@ -16,7 +16,15 @@
 package com.redhat.red.build.koji.model.json;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.redhat.red.build.koji.model.converter.StringListConverter;
+import org.commonjava.rwx.anno.Converter;
+import org.commonjava.rwx.anno.DataKey;
 import org.commonjava.rwx.anno.StructPart;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Created by dwalluck on 4/17/25.
@@ -24,15 +32,193 @@ import org.commonjava.rwx.anno.StructPart;
 @StructPart
 public class ImageExtraInfo
 {
-    @JsonCreator
+    @JsonProperty( "help" )
+    @DataKey( "help" )
+    private String help;
+
+    @JsonProperty( "index" )
+    @DataKey( "index" )
+    private ImageIndexExtraInfo index;
+
+    @JsonProperty( "isolated" )
+    @DataKey( "isolated" )
+    private Boolean isolated;
+
+    @JsonProperty( "media_types" )
+    @DataKey( "media_types" )
+    @Converter( StringListConverter.class )
+    private List<String> mediaTypes;
+
+    @JsonProperty( "parent_build_id" )
+    @DataKey( "parent_build_id" )
+    private Integer parentBuildId;
+
+    @JsonProperty( "parent_image_builds" )
+    @DataKey( "parent_image_builds" )
+    private Map<String, ImageParentImageBuildExtraInfo> parentImageBuilds;
+
+    @JsonProperty( "parent_images" )
+    @DataKey( "parent_images" )
+    @Converter( StringListConverter.class )
+    private List<String> parentImages;
+
+    @JsonProperty( "remote_sources" )
+    @DataKey( "remote_sources" )
+    private List<RemoteSourcesExtraInfo> remoteSources;
+
+    @JsonProperty( "yum_repourls" )
+    @DataKey( "yum_repourls" )
+    @Converter( StringListConverter.class )
+    private List<String> yumRepourls;
+
     public ImageExtraInfo()
     {
 
     }
 
+    @JsonCreator
+    public ImageExtraInfo( @JsonProperty( "help" ) String help,
+                           @JsonProperty( "index" ) ImageIndexExtraInfo index,
+                           @JsonProperty( "isolated" ) Boolean isolated,
+                           @JsonProperty( "media_types" ) List<String> mediaTypes,
+                           @JsonProperty( "parent_build_id" ) Integer parentBuildId,
+                           @JsonProperty( "parent_image_builds" ) Map<String, ImageParentImageBuildExtraInfo> parentImageBuilds,
+                           @JsonProperty( "parent_images" ) List<String> parentImages,
+                           @JsonProperty( "remote_sources" ) List<RemoteSourcesExtraInfo> remoteSources,
+                           @JsonProperty( "yum_repourls" ) List<String> yumRepourls )
+    {
+        this.help = help;
+        this.index = index;
+        this.isolated = isolated;
+        this.mediaTypes = mediaTypes;
+        this.parentBuildId = parentBuildId;
+        this.parentImageBuilds = parentImageBuilds;
+        this.parentImages = parentImages;
+        this.remoteSources = remoteSources;
+        this.yumRepourls = yumRepourls;
+    }
+
+    public Object getHelp()
+    {
+        return help;
+    }
+
+    public void setHelp(String help )
+    {
+        this.help = help;
+    }
+
+    public ImageIndexExtraInfo getIndex()
+    {
+        return index;
+    }
+
+    public void setIndex( ImageIndexExtraInfo index )
+    {
+        this.index = index;
+    }
+
+    public Boolean getIsolated()
+    {
+        return isolated;
+    }
+
+    public void setIsolated( Boolean isolated )
+    {
+        this.isolated = isolated;
+    }
+
+    public List<String> getMediaTypes()
+    {
+        return mediaTypes;
+    }
+
+    public void setMediaTypes( List<String> mediaTypes )
+    {
+        this.mediaTypes = mediaTypes;
+    }
+
+    public Integer getParentBuildId()
+    {
+        return parentBuildId;
+    }
+
+    public void setParentBuildId( Integer parentBuildId )
+    {
+        this.parentBuildId = parentBuildId;
+    }
+
+    public Map<String, ImageParentImageBuildExtraInfo> getParentImageBuilds()
+    {
+        return parentImageBuilds;
+    }
+
+    public void setParentImageBuilds(Map<String, ImageParentImageBuildExtraInfo> parentImageBuilds )
+    {
+        this.parentImageBuilds = parentImageBuilds;
+    }
+
+    public List<String> getParentImages()
+    {
+        return parentImages;
+    }
+
+    public void setParentImages( List<String> parentImages )
+    {
+        this.parentImages = parentImages;
+    }
+
+    public List<RemoteSourcesExtraInfo> getRemoteSources()
+    {
+        return remoteSources;
+    }
+
+    public void setRemoteSources( List<RemoteSourcesExtraInfo> remoteSources )
+    {
+        this.remoteSources = remoteSources;
+    }
+
+    public List<String> getYumRepourls()
+    {
+        return yumRepourls;
+    }
+
+    public void setYumRepourls( List<String> yumRepourls )
+    {
+        this.yumRepourls = yumRepourls;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        ImageExtraInfo that = ( ImageExtraInfo ) o;
+        return Objects.equals( help, that.help ) && Objects.equals( index, that.index ) && Objects.equals( isolated, that.isolated ) && Objects.equals( mediaTypes, that.mediaTypes ) && Objects.equals( parentBuildId, that.parentBuildId ) && Objects.equals( parentImageBuilds, that.parentImageBuilds ) && Objects.equals( parentImages, that.parentImages ) && Objects.equals( remoteSources, that.remoteSources ) && Objects.equals( yumRepourls, that.yumRepourls );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( help, index, isolated, mediaTypes, parentBuildId, parentImageBuilds, parentImages, remoteSources, yumRepourls );
+    }
+
     @Override
     public String toString()
     {
-        return "ImageExtraInfo{}";
+        return "ImageExtraInfo{" +
+                "help='" + help + '\'' +
+                ", index=" + index +
+                ", isolated=" + isolated +
+                ", mediaTypes=" + mediaTypes +
+                ", parentBuildId=" + parentBuildId +
+                ", parentImageBuilds=" + parentImageBuilds +
+                ", parentImages=" + parentImages +
+                ", remoteSources=" + remoteSources +
+                ", yumRepourls=" + yumRepourls +
+                '}';
     }
 }

--- a/src/main/java/com/redhat/red/build/koji/model/json/ImageIndexExtraInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/ImageIndexExtraInfo.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.red.build.koji.model.json;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.commonjava.rwx.anno.DataKey;
+import org.commonjava.rwx.anno.StructPart;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@StructPart
+public class ImageIndexExtraInfo
+{
+    @JsonProperty( "digests" )
+    @DataKey( "digests" )
+    private Map<String, String> digests;
+
+    @JsonProperty( "floating_tags" )
+    @DataKey( "floating_tags" )
+    private List<String> floatingTags;
+
+    @JsonProperty( "pull" )
+    @DataKey( "pull" )
+    private List<String> pull;
+
+    @JsonProperty( "tags" )
+    @DataKey( "tags" )
+    private List<String> tags;
+
+    @JsonProperty( "unique_tags" )
+    @DataKey( "unique_tags" )
+    private List<String> uniqueTags;
+
+    public ImageIndexExtraInfo()
+    {
+
+    }
+
+    @JsonCreator
+    public ImageIndexExtraInfo( @JsonProperty( "digests" ) Map<String, String> digests,  @JsonProperty( "floating_tags" ) List<String> floatingTags,  @JsonProperty( "pull" ) List<String> pull,  @JsonProperty( "tags" ) List<String> tags, @JsonProperty( "unique_tags" ) List<String> uniqueTags )
+    {
+        this.digests = digests;
+        this.floatingTags = floatingTags;
+        this.pull = pull;
+        this.tags = tags;
+        this.uniqueTags = uniqueTags;
+    }
+
+    public Map<String, String> getDigests()
+    {
+        return digests;
+    }
+
+    public void setDigests( Map<String, String> digests )
+    {
+        this.digests = digests;
+    }
+
+    public List<String> getFloatingTags()
+    {
+        return floatingTags;
+    }
+
+    public void setFloatingTags( List<String> floatingTags )
+    {
+        this.floatingTags = floatingTags;
+    }
+
+    public List<String> getPull()
+    {
+        return pull;
+    }
+
+    public void setPull( List<String> pull )
+    {
+        this.pull = pull;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags( List<String> tags )
+    {
+        this.tags = tags;
+    }
+
+    public List<String> getUniqueTags()
+    {
+        return uniqueTags;
+    }
+
+    public void setUniqueTags( List<String> uniqueTags )
+    {
+        this.uniqueTags = uniqueTags;
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        ImageIndexExtraInfo that = (ImageIndexExtraInfo) o;
+        return Objects.equals( digests, that.digests ) && Objects.equals( floatingTags, that.floatingTags ) && Objects.equals( pull, that.pull ) && Objects.equals( tags, that.tags ) && Objects.equals( uniqueTags, that.uniqueTags );
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(digests, floatingTags, pull, tags, uniqueTags);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ImageIndexExtraInfo{" +
+                "digests=" + digests +
+                ", floatingTags=" + floatingTags +
+                ", pull=" + pull +
+                ", tags=" + tags +
+                ", uniqueTags=" + uniqueTags +
+                '}';
+    }
+}

--- a/src/main/java/com/redhat/red/build/koji/model/json/ImageParentImageBuildExtraInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/ImageParentImageBuildExtraInfo.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.red.build.koji.model.json;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.commonjava.rwx.anno.DataKey;
+import org.commonjava.rwx.anno.StructPart;
+
+import java.util.Objects;
+
+@StructPart
+public class ImageParentImageBuildExtraInfo
+{
+    @DataKey( "id" )
+    @JsonProperty( "id" )
+    private Integer id;
+
+    @DataKey( "nvr" )
+    @JsonProperty( "nvr" )
+    private String nvr;
+
+    public ImageParentImageBuildExtraInfo()
+    {
+
+    }
+
+    @JsonCreator
+    public ImageParentImageBuildExtraInfo( @JsonProperty( "id" ) Integer id, @JsonProperty( "nvr" ) String nvr )
+    {
+        this.id = id;
+        this.nvr = nvr;
+    }
+
+    public Integer getId()
+    {
+        return id;
+    }
+
+    public void setId( Integer id )
+    {
+        this.id = id;
+    }
+
+    public String getNvr()
+    {
+        return nvr;
+    }
+
+    public void setNvr( String nvr )
+    {
+        this.nvr = nvr;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        ImageParentImageBuildExtraInfo that = (ImageParentImageBuildExtraInfo) o;
+        return Objects.equals( id, that.id ) && Objects.equals( nvr, that.nvr );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( id, nvr );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ImageParentImageBuildExtraInfo{" +
+                "id=" + id +
+                ", nvr='" + nvr + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/redhat/red/build/koji/model/json/KojiJsonConstants.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/KojiJsonConstants.java
@@ -70,6 +70,8 @@ public final class KojiJsonConstants
 
     public static final String HOST = "host";
 
+    public static final String ICM_INFO = "icm";
+
     public static final String ID = "id";
 
     public static final String IMAGE_INFO = "image";
@@ -94,6 +96,8 @@ public final class KojiJsonConstants
 
     public static final String OS = "os";
 
+    public static final String OSBS_BUILD = "osbs_build";
+
     public static final String OUTPUT = "output";
 
     public static final String RELEASE = "release";
@@ -115,6 +119,8 @@ public final class KojiJsonConstants
     public static final String SOURCE = "source";
 
     public static final String START_TIME = "start_time";
+
+    public static final String SUBMITTER = "submitter";
 
     public static final String TOOLS = "tools";
 

--- a/src/main/java/com/redhat/red/build/koji/model/json/OsbsBuildExtraInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/OsbsBuildExtraInfo.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.red.build.koji.model.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.redhat.red.build.koji.model.converter.StringListConverter;
+import org.commonjava.rwx.anno.Converter;
+import org.commonjava.rwx.anno.DataKey;
+import org.commonjava.rwx.anno.StructPart;
+
+import java.util.List;
+import java.util.Objects;
+
+@StructPart
+public class OsbsBuildExtraInfo
+{
+    @JsonProperty( "engine" )
+    @DataKey( "engine" )
+    private String engine;
+
+    @JsonProperty( "kind" )
+    @DataKey( "kind" )
+    private String kind;
+
+    @JsonProperty( "subtypes" )
+    @DataKey( "subtypes" )
+    @Converter( StringListConverter.class )
+    private List<String> subtypes;
+
+    public String getEngine()
+    {
+        return engine;
+    }
+
+    public void setEngine( String engine )
+    {
+        this.engine = engine;
+    }
+
+    public String getKind()
+    {
+        return kind;
+    }
+
+    public void setKind( String kind )
+    {
+        this.kind = kind;
+    }
+
+    public List<String> getSubtypes()
+    {
+        return subtypes;
+    }
+
+    public void setSubtypes( List<String> subtypes )
+    {
+        this.subtypes = subtypes;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        OsbsBuildExtraInfo that = (OsbsBuildExtraInfo) o;
+        return Objects.equals( engine, that.engine ) && Objects.equals( kind, that.kind ) && Objects.equals( subtypes, that.subtypes );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( engine, kind, subtypes );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "OsbsBuildExtraInfo{" +
+                "engine='" + engine + '\'' +
+                ", kind='" + kind + '\'' +
+                ", subtypes=" + subtypes +
+                '}';
+    }
+}

--- a/src/main/java/com/redhat/red/build/koji/model/json/TypeInfoExtraInfo.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/TypeInfoExtraInfo.java
@@ -23,8 +23,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
 import java.util.Objects;
 
+import static com.redhat.red.build.koji.model.json.KojiJsonConstants.ICM_INFO;
+import static com.redhat.red.build.koji.model.json.KojiJsonConstants.IMAGE_INFO;
 import static com.redhat.red.build.koji.model.json.KojiJsonConstants.NPM_TYPE_INFO;
 import static com.redhat.red.build.koji.model.json.KojiJsonConstants.REMOTE_SOURCES;
 import static com.redhat.red.build.koji.model.json.KojiJsonConstants.REMOTE_SOURCE_FILE;
@@ -38,7 +41,7 @@ public class TypeInfoExtraInfo
 {
     @JsonProperty( REMOTE_SOURCES )
     @DataKey( REMOTE_SOURCES )
-    private RemoteSourcesExtraInfo remoteSourcesExtraInfo;
+    private List<RemoteSourcesExtraInfo> remoteSourcesExtraInfo;
 
     @JsonProperty( REMOTE_SOURCE_FILE )
     @DataKey( REMOTE_SOURCE_FILE )
@@ -48,18 +51,28 @@ public class TypeInfoExtraInfo
     @DataKey( NPM_TYPE_INFO )
     private NpmTypeInfoExtraInfo npmTypeInfoExtraInfo;
 
-    public TypeInfoExtraInfo( @JsonProperty( REMOTE_SOURCES ) RemoteSourcesExtraInfo remoteSourcesExtraInfo )
-    {
-        this.remoteSourcesExtraInfo = remoteSourcesExtraInfo;
-    }
+    @JsonProperty( IMAGE_INFO )
+    @DataKey( IMAGE_INFO )
+    private ImageExtraInfo imageExtraInfo;
+
+    @JsonProperty( ICM_INFO )
+    @DataKey( ICM_INFO )
+    private IcmExtraInfo icmExtraInfo;
 
     @JsonCreator
-    public TypeInfoExtraInfo(
-            @JsonProperty( REMOTE_SOURCE_FILE ) RemoteSourceFileExtraInfo sourceFileInfo,
-            @JsonProperty( NPM_TYPE_INFO ) NpmTypeInfoExtraInfo npm )
+    public TypeInfoExtraInfo( @JsonProperty( REMOTE_SOURCE_FILE ) RemoteSourceFileExtraInfo sourceFileInfo,
+                              @JsonProperty( NPM_TYPE_INFO ) NpmTypeInfoExtraInfo npm,
+                              @JsonProperty( REMOTE_SOURCES ) List<RemoteSourcesExtraInfo> remoteSourcesExtraInfo )
     {
         this.remoteSourceFileExtraInfo = sourceFileInfo;
         this.npmTypeInfoExtraInfo = npm;
+        this.remoteSourcesExtraInfo = remoteSourcesExtraInfo;
+    }
+
+
+    public TypeInfoExtraInfo( @JsonProperty( REMOTE_SOURCES ) List<RemoteSourcesExtraInfo> sourcesExtraInfo )
+    {
+        this.remoteSourcesExtraInfo = sourcesExtraInfo;
     }
 
     public TypeInfoExtraInfo( @JsonProperty( NPM_TYPE_INFO ) NpmTypeInfoExtraInfo npm )
@@ -71,12 +84,12 @@ public class TypeInfoExtraInfo
     {
     }
 
-    public RemoteSourcesExtraInfo getRemoteSourcesExtraInfo()
+    public List<RemoteSourcesExtraInfo> getRemoteSourcesExtraInfo()
     {
         return remoteSourcesExtraInfo;
     }
 
-    public void setRemoteSourcesExtraInfo( RemoteSourcesExtraInfo remoteSourcesExtraInfo )
+    public void setRemoteSourcesExtraInfo(List<RemoteSourcesExtraInfo> remoteSourcesExtraInfo )
     {
         this.remoteSourcesExtraInfo = remoteSourcesExtraInfo;
     }
@@ -101,6 +114,26 @@ public class TypeInfoExtraInfo
         this.npmTypeInfoExtraInfo = npmTypeInfoExtraInfo;
     }
 
+    public ImageExtraInfo getImageExtraInfo()
+    {
+        return imageExtraInfo;
+    }
+
+    public void setImageExtraInfo( ImageExtraInfo imageExtraInfo )
+    {
+        this.imageExtraInfo = imageExtraInfo;
+    }
+
+    public IcmExtraInfo getIcmExtraInfo()
+    {
+        return icmExtraInfo;
+    }
+
+    public void setIcmExtraInfo( IcmExtraInfo icmExtraInfo )
+    {
+        this.icmExtraInfo = icmExtraInfo;
+    }
+
     @Override
     public boolean equals( Object o )
     {
@@ -110,17 +143,17 @@ public class TypeInfoExtraInfo
         }
 
         TypeInfoExtraInfo that = (TypeInfoExtraInfo) o;
-        return Objects.equals( remoteSourcesExtraInfo, that.remoteSourcesExtraInfo ) && Objects.equals( remoteSourceFileExtraInfo, that.remoteSourceFileExtraInfo ) && Objects.equals( npmTypeInfoExtraInfo, that.npmTypeInfoExtraInfo );
+        return Objects.equals( remoteSourcesExtraInfo, that.remoteSourcesExtraInfo ) && Objects.equals( remoteSourceFileExtraInfo, that.remoteSourceFileExtraInfo ) && Objects.equals( npmTypeInfoExtraInfo, that.npmTypeInfoExtraInfo ) && Objects.equals( imageExtraInfo, that.imageExtraInfo ) && Objects.equals( icmExtraInfo, that.icmExtraInfo );
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( remoteSourcesExtraInfo, remoteSourceFileExtraInfo, npmTypeInfoExtraInfo );
+        return Objects.hash( remoteSourcesExtraInfo, remoteSourceFileExtraInfo, npmTypeInfoExtraInfo, imageExtraInfo, icmExtraInfo );
     }
 
     @Override
     public String toString() {
-        return "TypeInfoExtraInfo{remoteSourcesExtraInfo=" + remoteSourcesExtraInfo + ", remoteSourceFileExtraInfo=" + remoteSourceFileExtraInfo + ", npmTypeInfoExtraInfo=" + npmTypeInfoExtraInfo + '}';
+        return "TypeInfoExtraInfo{remoteSourcesExtraInfo=" + remoteSourcesExtraInfo + ", remoteSourceFileExtraInfo=" + remoteSourceFileExtraInfo + ", npmTypeInfoExtraInfo=" + npmTypeInfoExtraInfo + ", imageExtraInfo=" + imageExtraInfo + ", icmExtraInfo=" + icmExtraInfo + '}';
     }
 }

--- a/src/main/java/com/redhat/red/build/koji/model/json/util/BuildExtraInfoDeserializer.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/util/BuildExtraInfoDeserializer.java
@@ -22,10 +22,12 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.redhat.red.build.koji.model.json.BuildExtraInfo;
+import com.redhat.red.build.koji.model.json.ImageExtraInfo;
 import com.redhat.red.build.koji.model.json.MavenExtraInfo;
 
 import java.io.IOException;
 
+import static com.redhat.red.build.koji.model.json.KojiJsonConstants.IMAGE_INFO;
 import static com.redhat.red.build.koji.model.json.KojiJsonConstants.MAVEN_INFO;
 
 /**
@@ -58,6 +60,14 @@ public class BuildExtraInfoDeserializer
 
                         MavenExtraInfo mvnInfo = (MavenExtraInfo) mvnDeser.deserialize( jp, ctxt );
                         return new BuildExtraInfo( mvnInfo );
+                    }
+                    case ( IMAGE_INFO ):
+                    {
+                        JsonDeserializer<Object> imageDeser =
+                                ctxt.findRootValueDeserializer( ctxt.constructType( ImageExtraInfo.class ) );
+
+                        ImageExtraInfo imageInfo = (ImageExtraInfo) imageDeser.deserialize( jp, ctxt );
+                        return new BuildExtraInfo( imageInfo );
                     }
                     default:
                     {

--- a/src/main/java/com/redhat/red/build/koji/model/json/util/KojiJsonModule.java
+++ b/src/main/java/com/redhat/red/build/koji/model/json/util/KojiJsonModule.java
@@ -16,7 +16,7 @@
 package com.redhat.red.build.koji.model.json.util;
 
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.redhat.red.build.koji.model.json.BuildExtraInfo;
+//import com.redhat.red.build.koji.model.json.BuildExtraInfo;
 import com.redhat.red.build.koji.model.json.BuildSource;
 import com.redhat.red.build.koji.model.json.FileExtraInfo;
 import org.commonjava.atlas.maven.ident.ref.ProjectVersionRef;
@@ -39,8 +39,8 @@ public class KojiJsonModule
         addSerializer( Date.class, new SecondsSinceEpochSerializer() );
         addDeserializer( Date.class, new SecondsSinceEpochDeserializer() );
 
-        addSerializer( BuildExtraInfo.class, new BuildExtraInfoSerializer( BuildExtraInfo.class ) );
-        addDeserializer( BuildExtraInfo.class, new BuildExtraInfoDeserializer() );
+        //addSerializer( BuildExtraInfo.class, new BuildExtraInfoSerializer( BuildExtraInfo.class ) );
+        //addDeserializer( BuildExtraInfo.class, new BuildExtraInfoDeserializer() );
 
         addSerializer( FileExtraInfo.class, new FileExtraInfoSerializer( FileExtraInfo.class ) );
         addDeserializer( FileExtraInfo.class, new FileExtraInfoDeserializer() );

--- a/src/test/java/com/redhat/red/build/koji/model/json/BuildExtraInfoTest.java
+++ b/src/test/java/com/redhat/red/build/koji/model/json/BuildExtraInfoTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.red.build.koji.model.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.red.build.koji.model.json.util.KojiObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+
+public class BuildExtraInfoTest
+{
+    private static final ObjectMapper MAPPER = new KojiObjectMapper();
+
+    @Test
+    public void testParsing() throws IOException {
+        URL url = BuildExtraInfoTest.class.getResource( "/extra.json" );
+        assertThat( url, notNullValue() );
+        BuildExtraInfo extra = MAPPER.readValue( url, BuildExtraInfo.class );
+        assertThat( extra, notNullValue() );
+        assertThat( extra.getContainerKojiTaskId(), equalTo( 65888573 ) );
+        ImageExtraInfo image = extra.getImageExtraInfo();
+        assertThat( image, notNullValue() );
+        assertThat( image.getHelp(), nullValue() );
+        checkIndex( image.getIndex() );
+        assertThat( image.getIsolated(), equalTo( false ) );
+        assertThat( image.getMediaTypes(), hasItems( "application/vnd.docker.distribution.manifest.list.v2+json", "application/vnd.docker.distribution.manifest.v1+json", "application/vnd.docker.distribution.manifest.v2+json" ) );
+        assertThat( image.getParentBuildId(), equalTo( 3388882 ) );
+        checkParentImageBuilds( image.getParentImageBuilds() );
+        assertThat( image.getParentImages(), hasItems( "openshift/golang-builder:v1.20.12-202410181045.g92d4921.el8", "openshift/ose-base:v4.14.0.20241113.044138" ) );
+        assertThat( image.getRemoteSources(), hasItems( new RemoteSourcesExtraInfo( null, "cachito-gomod-with-deps","https://cachito/api/v1/requests/1755373" ) ) );
+        assertThat( image.getYumRepourls(), hasItems( "https://pkgs/cgit/containers/ose-cluster-cloud-controller-manager-operator/plain/.oit/signed.repo?h=rhaos-4.14-rhel-8&id=8a4559dd22257ed70022838ef0df242622da92c5" ) );
+        checkOsbsBuild( extra.getOsbsBuild() );
+        assertThat( extra.getSubmitter(), equalTo( "osbs-brew-access" ) );
+        checkTypeInfo(  extra.getTypeInfo() );
+    }
+
+    private static void checkTypeInfo( TypeInfoExtraInfo typeInfo )
+    {
+        assertThat( typeInfo, notNullValue() );
+        List<RemoteSourcesExtraInfo> remoteSourcesExtraInfo = typeInfo.getRemoteSourcesExtraInfo();
+        assertThat( remoteSourcesExtraInfo, hasItems( new RemoteSourcesExtraInfo( Arrays.asList( "remote-source-cachito-gomod-with-deps.json", "remote-source-cachito-gomod-with-deps.tar.gz", "remote-source-cachito-gomod-with-deps.env.json", "remote-source-cachito-gomod-with-deps.config.json" ), "cachito-gomod-with-deps", "https://cachito/api/v1/requests/1755373" ) ) );
+        IcmExtraInfo icm = typeInfo.getIcmExtraInfo();
+        assertThat( icm, notNullValue() );
+        assertThat( icm.getArchives(), hasItems(  "icm-s390x.json", "icm-ppc64le.json", "icm-x86_64.json", "icm-aarch64.json" ) );
+        assertThat( icm.getName(), equalTo( "icm" ) );
+    }
+
+    private static void checkOsbsBuild( OsbsBuildExtraInfo osbsBuild )
+    {
+        assertThat( osbsBuild, notNullValue() );
+        assertThat( osbsBuild.getEngine(), equalTo( "podman" ) );
+        assertThat( osbsBuild.getKind(), equalTo( "container_build" ) );
+        assertThat( osbsBuild.getSubtypes(), hasSize( 0 ));
+    }
+
+    private static void checkParentImageBuilds( Map<String, ImageParentImageBuildExtraInfo> parentImageBuilds )
+    {
+        assertThat( parentImageBuilds, aMapWithSize( 2 ) );
+        assertThat( parentImageBuilds, hasEntry( "registry/rh-osbs/openshift-golang-builder:v1.20.12-202410181045.g92d4921.el8", new ImageParentImageBuildExtraInfo( 3347950, "openshift-golang-builder-container-v1.20.12-202410181045.g92d4921.el8" )  ) );
+        assertThat( parentImageBuilds, hasEntry( "registry/rh-osbs/openshift-ose-base:v4.14.0.20241113.044138", new ImageParentImageBuildExtraInfo( 3388882, "openshift-enterprise-base-container-v4.14.0-202411130434.p0.g03e5f40.assembly.stream.el8" )  ) );
+    }
+
+    private static void checkIndex( ImageIndexExtraInfo index )
+    {
+        assertThat( index.getDigests(), aMapWithSize( 1 ) );
+        assertThat( index.getDigests(),  hasEntry(  "application/vnd.docker.distribution.manifest.list.v2+json", "sha256:4a0c89af8c0cbaafd369b505b7783eab15cd6f5af1c5ffcf0f424aacadc4dca9" ) );
+        assertThat( index.getFloatingTags(), hasItems( "assembly.stream", "v4.14.0", "v4.14", "v4.14.0.20241113.044138" ) );
+        assertThat( index.getPull(), hasItems( "registry/rh-osbs/openshift-ose-cluster-cloud-controller-manager-operator@sha256:4a0c89af8c0cbaafd369b505b7783eab15cd6f5af1c5ffcf0f424aacadc4dca9", "registry/rh-osbs/openshift-ose-cluster-cloud-controller-manager-operator:v4.14.0-202411130434.p0.ga0b9c0d.assembly.stream.el8" ) );
+        assertThat( index.getTags(), hasItems( "v4.14.0-202411130434.p0.ga0b9c0d.assembly.stream.el8" ) );
+        assertThat( index.getUniqueTags(), hasItems( "rhaos-4.14-rhel-8-containers-candidate-74394-20241113062440" ) );
+    }
+}

--- a/src/test/resources/extra.json
+++ b/src/test/resources/extra.json
@@ -1,0 +1,140 @@
+{
+    "container_koji_task_id": 65888573,
+    "image": {
+        "help": null,
+        "index": {
+            "digests": {
+                "application/vnd.docker.distribution.manifest.list.v2+json": "sha256:4a0c89af8c0cbaafd369b505b7783eab15cd6f5af1c5ffcf0f424aacadc4dca9"
+            },
+            "floating_tags": [
+                "assembly.stream",
+                "v4.14.0",
+                "v4.14",
+                "v4.14.0.20241113.044138"
+            ],
+            "pull": [
+                "registry/rh-osbs/openshift-ose-cluster-cloud-controller-manager-operator@sha256:4a0c89af8c0cbaafd369b505b7783eab15cd6f5af1c5ffcf0f424aacadc4dca9",
+                "registry/rh-osbs/openshift-ose-cluster-cloud-controller-manager-operator:v4.14.0-202411130434.p0.ga0b9c0d.assembly.stream.el8"
+            ],
+            "tags": [
+                "v4.14.0-202411130434.p0.ga0b9c0d.assembly.stream.el8"
+            ],
+            "unique_tags": [
+                "rhaos-4.14-rhel-8-containers-candidate-74394-20241113062440"
+            ]
+        },
+        "isolated": false,
+        "media_types": [
+            "application/vnd.docker.distribution.manifest.list.v2+json",
+            "application/vnd.docker.distribution.manifest.v1+json",
+            "application/vnd.docker.distribution.manifest.v2+json"
+        ],
+        "parent_build_id": 3388882,
+        "parent_image_builds": {
+            "registry/rh-osbs/openshift-golang-builder:v1.20.12-202410181045.g92d4921.el8": {
+                "id": 3347950,
+                "nvr": "openshift-golang-builder-container-v1.20.12-202410181045.g92d4921.el8"
+            },
+            "registry/rh-osbs/openshift-ose-base:v4.14.0.20241113.044138": {
+                "id": 3388882,
+                "nvr": "openshift-enterprise-base-container-v4.14.0-202411130434.p0.g03e5f40.assembly.stream.el8"
+            }
+        },
+        "parent_images": [
+            "openshift/golang-builder:v1.20.12-202410181045.g92d4921.el8",
+            "openshift/ose-base:v4.14.0.20241113.044138"
+        ],
+        "remote_sources": [
+            {
+                "name": "cachito-gomod-with-deps",
+                "url": "https://cachito/api/v1/requests/1755373"
+            }
+        ],
+        "yum_repourls": [
+            "https://pkgs/cgit/containers/ose-cluster-cloud-controller-manager-operator/plain/.oit/signed.repo?h=rhaos-4.14-rhel-8&id=8a4559dd22257ed70022838ef0df242622da92c5"
+        ]
+    },
+    "osbs_build": {
+        "engine": "podman",
+        "kind": "container_build",
+        "subtypes": []
+    },
+    "submitter": "osbs-brew-access",
+    "typeinfo": {
+        "icm": {
+            "archives": [
+                "icm-s390x.json",
+                "icm-ppc64le.json",
+                "icm-x86_64.json",
+                "icm-aarch64.json"
+            ],
+            "name": "icm"
+        },
+        "image": {
+            "help": null,
+            "index": {
+                "digests": {
+                    "application/vnd.docker.distribution.manifest.list.v2+json": "sha256:4a0c89af8c0cbaafd369b505b7783eab15cd6f5af1c5ffcf0f424aacadc4dca9"
+                },
+                "floating_tags": [
+                    "assembly.stream",
+                    "v4.14.0",
+                    "v4.14",
+                    "v4.14.0.20241113.044138"
+                ],
+                "pull": [
+                    "registry/rh-osbs/openshift-ose-cluster-cloud-controller-manager-operator@sha256:4a0c89af8c0cbaafd369b505b7783eab15cd6f5af1c5ffcf0f424aacadc4dca9",
+                    "registry/rh-osbs/openshift-ose-cluster-cloud-controller-manager-operator:v4.14.0-202411130434.p0.ga0b9c0d.assembly.stream.el8"
+                ],
+                "tags": [
+                    "v4.14.0-202411130434.p0.ga0b9c0d.assembly.stream.el8"
+                ],
+                "unique_tags": [
+                    "rhaos-4.14-rhel-8-containers-candidate-74394-20241113062440"
+                ]
+            },
+            "isolated": false,
+            "media_types": [
+                "application/vnd.docker.distribution.manifest.list.v2+json",
+                "application/vnd.docker.distribution.manifest.v1+json",
+                "application/vnd.docker.distribution.manifest.v2+json"
+            ],
+            "parent_build_id": 3388882,
+            "parent_image_builds": {
+                "registry/rh-osbs/openshift-golang-builder:v1.20.12-202410181045.g92d4921.el8": {
+                    "id": 3347950,
+                    "nvr": "openshift-golang-builder-container-v1.20.12-202410181045.g92d4921.el8"
+                },
+                "registry/rh-osbs/openshift-ose-base:v4.14.0.20241113.044138": {
+                    "id": 3388882,
+                    "nvr": "openshift-enterprise-base-container-v4.14.0-202411130434.p0.g03e5f40.assembly.stream.el8"
+                }
+            },
+            "parent_images": [
+                "openshift/golang-builder:v1.20.12-202410181045.g92d4921.el8",
+                "openshift/ose-base:v4.14.0.20241113.044138"
+            ],
+            "remote_sources": [
+                {
+                    "name": "cachito-gomod-with-deps",
+                    "url": "https://cachito/api/v1/requests/1755373"
+                }
+            ],
+            "yum_repourls": [
+                "https://pkgs/cgit/containers/ose-cluster-cloud-controller-manager-operator/plain/.oit/signed.repo?h=rhaos-4.14-rhel-8&id=8a4559dd22257ed70022838ef0df242622da92c5"
+            ]
+        },
+        "remote-sources": [
+            {
+                "archives": [
+                    "remote-source-cachito-gomod-with-deps.json",
+                    "remote-source-cachito-gomod-with-deps.tar.gz",
+                    "remote-source-cachito-gomod-with-deps.env.json",
+                    "remote-source-cachito-gomod-with-deps.config.json"
+                ],
+                "name": "cachito-gomod-with-deps",
+                "url": "https://cachito/api/v1/requests/1755373"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This adds two new fields to the extra map, "osbs_build" and "submitter", and two new fields to the extra type info map, "image" and "icm".

Although the "image" field existed in the extra map, it did not exist in the type info map. This also adds missing image fields, including "index" and "parent_image_builds".

This fixes several issues with "remote-sources". The type should have been a list and not a single object. The JSON creator also did not work.

This adds a test for parsing the extra info from the JSON map. It removes the installation of the Koji JSON extra map serializers from the Koji JSON module as the implementation is incomplete and it should not be necessary.